### PR TITLE
fix: Force sacct to look at the last 2 days

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -209,7 +209,7 @@ class Executor(RemoteExecutor):
                 (status_of_jobs, sacct_query_duration) = await self.job_stati(
                     # -X: only show main job, no substeps
                     f"sacct -X --parsable2 --noheader --format=JobIdRaw,State "
-                    f"--starttime now-4weeks --endtime now --name {self.run_uuid}"
+                    f"--starttime now-2days --endtime now --name {self.run_uuid}"
                 )
                 if status_of_jobs is None and sacct_query_duration is None:
                     self.logger.debug(f"could not check status of job {self.run_uuid}")

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -234,9 +234,7 @@ class Executor(RemoteExecutor):
                     active_jobs_seen_by_sacct
                     - active_jobs_ids_with_current_sacct_status
                 )
-                self.logger.debug(
-                    f"missing_sacct_status are: {missing_sacct_status}"
-                )
+                self.logger.debug(f"missing_sacct_status are: {missing_sacct_status}")
                 if not missing_sacct_status:
                     break
             if i >= status_attempts - 1:

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -221,7 +221,8 @@ class Executor(RemoteExecutor):
                     set(status_of_jobs.keys()) & active_jobs_ids
                 )
                 self.logger.debug(
-                    f"active_jobs_ids_with_current_sacct_status are: {active_jobs_ids_with_current_sacct_status}"
+                    f"active_jobs_ids_with_current_sacct_status are: "
+                    f"{active_jobs_ids_with_current_sacct_status}"
                 )
                 active_jobs_seen_by_sacct = (
                     active_jobs_seen_by_sacct

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -209,7 +209,7 @@ class Executor(RemoteExecutor):
                 (status_of_jobs, sacct_query_duration) = await self.job_stati(
                     # -X: only show main job, no substeps
                     f"sacct -X --parsable2 --noheader --format=JobIdRaw,State "
-                    f"--name {self.run_uuid}"
+                    f"--starttime now-4weeks --endtime now --name {self.run_uuid}"
                 )
                 if status_of_jobs is None and sacct_query_duration is None:
                     self.logger.debug(f"could not check status of job {self.run_uuid}")

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -220,6 +220,9 @@ class Executor(RemoteExecutor):
                 active_jobs_ids_with_current_sacct_status = (
                     set(status_of_jobs.keys()) & active_jobs_ids
                 )
+                self.logger.debug(
+                    f"active_jobs_ids_with_current_sacct_status are: {active_jobs_ids_with_current_sacct_status}"
+                )
                 active_jobs_seen_by_sacct = (
                     active_jobs_seen_by_sacct
                     | active_jobs_ids_with_current_sacct_status
@@ -230,6 +233,9 @@ class Executor(RemoteExecutor):
                 missing_sacct_status = (
                     active_jobs_seen_by_sacct
                     - active_jobs_ids_with_current_sacct_status
+                )
+                self.logger.debug(
+                    f"missing_sacct_status are: {missing_sacct_status}"
                 )
                 if not missing_sacct_status:
                     break


### PR DESCRIPTION
Possible fix to snakemake/snakemake#1227.

How often does the rate limiter checks `sacct`?