### PR TITLE
fix: Use sacct syntax that is compatible with slurm < 20.11.0

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -206,7 +206,7 @@ class Executor(RemoteExecutor):
                 (status_of_jobs, sacct_query_duration) = await self.job_stati(
                     # -X: only show main job, no substeps
                     f"sacct -X --parsable2 --noheader --format=JobIdRaw,State "
-                    f"--starttime {datetime.utcnow() - timedelta(days=2):%Y-%m-%dT%H} "
+                    f"--starttime {datetime.utcnow() - timedelta(days=2):%Y-%m-%dT%H:00} "
                     f"--endtime now --name {self.run_uuid}"
                 )
                 if status_of_jobs is None and sacct_query_duration is None:

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -8,6 +8,7 @@ from io import StringIO
 import os
 import subprocess
 import time
+from datetime import datetime, timedelta
 from typing import List, Generator
 import uuid
 from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
@@ -205,7 +206,8 @@ class Executor(RemoteExecutor):
                 (status_of_jobs, sacct_query_duration) = await self.job_stati(
                     # -X: only show main job, no substeps
                     f"sacct -X --parsable2 --noheader --format=JobIdRaw,State "
-                    f"--starttime now-2days --endtime now --name {self.run_uuid}"
+                    f"--starttime {datetime.utcnow() - timedelta(days=2):%Y-%m-%dT%H} "
+                    f"--endtime now --name {self.run_uuid}"
                 )
                 if status_of_jobs is None and sacct_query_duration is None:
                     self.logger.debug(f"could not check status of job {self.run_uuid}")


### PR DESCRIPTION
Closes #25 

Tested with slurm 20.02.07

Not a great contribution in terms of code readability, but it'd ensure that the plugin works with older slurm versions. 