### PR TITLE
feat: add wildcards to output and comment

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -66,7 +66,7 @@ class Executor(RemoteExecutor):
         # snakemake_interface_executor_plugins.executors.base.SubmittedJobInfo.
 
         log_folder = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
-        
+
         try:
             wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
         except AttributeError:

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -65,7 +65,11 @@ class Executor(RemoteExecutor):
         # snakemake_interface_executor_plugins.executors.base.SubmittedJobInfo.
 
         log_folder = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
-        wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
+        
+        try:
+            wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
+        except AttributeError:
+            wildcard_str = ""
 
         slurm_logfile = os.path.abspath(
             f".snakemake/slurm_logs/{log_folder}/%j{wildcard_str}.log"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -67,7 +67,9 @@ class Executor(RemoteExecutor):
         log_folder = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
         wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
 
-        slurm_logfile = os.path.abspath(f".snakemake/slurm_logs/{log_folder}/%j{wildcard_str}.log")
+        slurm_logfile = os.path.abspath(
+            f".snakemake/slurm_logs/{log_folder}/%j{wildcard_str}.log"
+        )
         os.makedirs(os.path.dirname(slurm_logfile), exist_ok=True)
 
         # generic part of a submission string:

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -65,8 +65,9 @@ class Executor(RemoteExecutor):
         # snakemake_interface_executor_plugins.executors.base.SubmittedJobInfo.
 
         log_folder = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
+        wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
 
-        slurm_logfile = os.path.abspath(f".snakemake/slurm_logs/{log_folder}/%j.log")
+        slurm_logfile = os.path.abspath(f".snakemake/slurm_logs/{log_folder}/%j{wildcard_str}.log")
         os.makedirs(os.path.dirname(slurm_logfile), exist_ok=True)
 
         # generic part of a submission string:


### PR DESCRIPTION
Add rule wildcards to slurm output logs and job comments. Not sure if this will need extra checks for when `job` is a group instead of a rule.