### PR TITLE
fix: replace os.path.sep in wildcard strings with "" in logfile name

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -69,6 +69,7 @@ class Executor(RemoteExecutor):
 
         try:
             wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
+            wildcard_str = wildcard_str.replace("/", ".")
         except AttributeError:
             wildcard_str = ""
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -69,7 +69,7 @@ class Executor(RemoteExecutor):
 
         try:
             wildcard_str = f".{'_'.join(job.wildcards)}" if job.wildcards else ""
-            wildcard_str = wildcard_str.replace("/", ".")
+            wildcard_str = wildcard_str.replace(os.path.sep, "")
         except AttributeError:
             wildcard_str = ""
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -68,7 +68,7 @@ class Executor(RemoteExecutor):
         log_folder = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
 
         try:
-            wildcard_str = f"_{'_'.join(job.wildcards)}" if job.wildcards else ""
+            wildcard_str = f".{'_'.join(job.wildcards)}" if job.wildcards else ""
             wildcard_str = wildcard_str.replace("/", ".")
         except AttributeError:
             wildcard_str = ""


### PR DESCRIPTION
This replaces "/" with "." in logfile name for wildcards to make sure we can create parent directory for output log file, fixing #47. I chose "." as it is different than the wildcard separator "_", and having the wildcard name be faithful isn't super critical because the name is unique from the job id anyway.