### PR TITLE
feat: warning if run in job

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -2,7 +2,7 @@
 
 ## The general Idea
 
-To use this plugin, log in to your cluster's head node (sometimes called the "login" node), activate your environment as usual and start Snakemake. Snakemake will then submit your jobs as cluster jobs.
+To use this plugin, log in to your cluster's head node (sometimes called the "login" node), activate your environment as usual, and start Snakemake. Snakemake will then submit your jobs as cluster jobs.
 
 ## Specifying Account and Partition
 
@@ -219,6 +219,12 @@ export SNAKEMAKE_PROFILE="$HOME/.config/snakemake"
 ```
 
 Further note, that there is further development ongoing to enable differentiation of file access patterns. 
+
+## Nesting Jobs (or Running this Plugin within a Job)
+
+Some environments provide a shell within a SLURM job, for instance, IDEs started in on-demand context. If Snakemake attempts to use this plugin to spawn jobs on the cluster, this may work just as intended. Or it might not: depending on cluster settings or individual settings, submitted jobs may be ill-parameterized or will not find the right environment.
+
+If the plugin detects to be running within a job, it will therefore issue a warning and stop for 5 seconds.
 
 ## Summary:
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -49,10 +49,21 @@ common_settings = CommonSettings(
 # Implementation of your executor
 class Executor(RemoteExecutor):
     def __post_init__(self):
+        # run check whether we are running in a SLURM job context
+        self.warn_on_jobcontext()
         self.run_uuid = str(uuid.uuid4())
         self.logger.info(f"SLURM run ID: {self.run_uuid}")
         self._fallback_account_arg = None
         self._fallback_partition = None
+
+    def warn_on_jobcontext(self, done=None):
+        if not done:
+            if "SLURM_JOB_ID" in os.environ:
+                self.logger.warning(
+                    "Running Snakemake in a SLURM within a job may lead to unexpected behavior. Please run Snakemake directly on the head node."
+                )
+                time.sleep(5)
+        done = True
 
     def additional_general_args(self):
         return "--executor slurm-jobstep --jobs 1"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -60,7 +60,9 @@ class Executor(RemoteExecutor):
         if not done:
             if "SLURM_JOB_ID" in os.environ:
                 self.logger.warning(
-                    "Running Snakemake in a SLURM within a job may lead to unexpected behavior. Please run Snakemake directly on the head node."
+                    "Running Snakemake in a SLURM within a job may lead"
+                    " to unexpected behavior. Please run Snakemake directly"
+                    " on the head node."
                 )
                 time.sleep(5)
         done = True


### PR DESCRIPTION
Already, two issues (#75 and #22) seem to result from running Snakemake in a SLURM job context and using this executor plugin. This PR introduces detecting if triggered within a SLURM job and issuing a warning accordingly.

In principle, the plugin may work in job context. Submitting jobs from jobs has always been a highlight of SLURM. However, settings may lead to unintended behaviour (and would do so without Snakemake, presumably). Hence, we can only warn from the executor. 