### PR TITLE
fix: null byte account guess

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -414,7 +414,7 @@ class Executor(RemoteExecutor):
             sacct_out = subprocess.check_output(
                 cmd, shell=True, text=True, stderr=subprocess.PIPE
             )
-            return sacct_out.strip()
+            return sacct_out.strip().replace("(null)", "")
         except subprocess.CalledProcessError as e:
             self.logger.warning(
                 f"No account was given, not able to get a SLURM account via sacct: "

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -376,6 +376,7 @@ class Executor(RemoteExecutor):
                 account = self.get_account()
                 if account:
                     self.logger.warning(f"Guessed SLURM account: {account}")
+                    self.test_account(f"{account}")
                     self._fallback_account_arg = f" -A {account}"
                 else:
                     self.logger.warning(

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -414,7 +414,7 @@ class Executor(RemoteExecutor):
             sacct_out = subprocess.check_output(
                 cmd, shell=True, text=True, stderr=subprocess.PIPE
             )
-            return sacct_out.strip().replace("(null)", "")
+            return sacct_out.replace("(null)", "").strip()
         except subprocess.CalledProcessError as e:
             self.logger.warning(
                 f"No account was given, not able to get a SLURM account via sacct: "


### PR DESCRIPTION
attempt to ensure that a '(null)' byte does not overthrow the account testing.