### PR TITLE
fix: allowing for accounts containing whitespace

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -369,7 +369,7 @@ class Executor(RemoteExecutor):
             # here, we check whether the given or guessed account is valid
             # if not, a WorkflowError is raised
             self.test_account(job.resources.slurm_account)
-            return f" -A {job.resources.slurm_account}"
+            return f" -A '{job.resources.slurm_account}'"
         else:
             if self._fallback_account_arg is None:
                 self.logger.warning("No SLURM account given, trying to guess.")
@@ -436,7 +436,7 @@ class Executor(RemoteExecutor):
                 f"'{account}' with sacctmgr: {e.stderr}"
             )
 
-        accounts = accounts.split()
+        accounts = [_.strip() for _ in accounts.split('\n') if len(_)]
 
         if account not in accounts:
             raise WorkflowError(

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -442,7 +442,10 @@ class Executor(RemoteExecutor):
                 f"'{account}' with sacctmgr: {e.stderr}"
             )
 
-        accounts = [_.strip() for _ in accounts.split("\n") if _]
+        # The set() has been introduced during review. It eleminates
+        # duplicates. They are not harmful, but disturbing to read.
+        # the set eliminates duplicates - not harmful, but disturbing to read
+        accounts = set(_.strip() for _ in accounts.split("\n") if _)
 
         if account not in accounts:
             raise WorkflowError(

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -442,9 +442,8 @@ class Executor(RemoteExecutor):
                 f"'{account}' with sacctmgr: {e.stderr}"
             )
 
-        # The set() has been introduced during review. It eleminates
+        # The set() has been introduced during review to eliminate
         # duplicates. They are not harmful, but disturbing to read.
-        # the set eliminates duplicates - not harmful, but disturbing to read
         accounts = set(_.strip() for _ in accounts.split("\n") if _)
 
         if account not in accounts:

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -436,7 +436,7 @@ class Executor(RemoteExecutor):
                 f"'{account}' with sacctmgr: {e.stderr}"
             )
 
-        accounts = [_.strip() for _ in accounts.split('\n') if len(_)]
+        accounts = [_.strip() for _ in accounts.split("\n") if len(_)]
 
         if account not in accounts:
             raise WorkflowError(

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -436,7 +436,7 @@ class Executor(RemoteExecutor):
                 f"'{account}' with sacctmgr: {e.stderr}"
             )
 
-        accounts = [_.strip() for _ in accounts.split("\n") if len(_)]
+        accounts = [_.strip() for _ in accounts.split("\n") if _]
 
         if account not in accounts:
             raise WorkflowError(


### PR DESCRIPTION
As [reported](https://github.com/snakemake/snakemake/issues/2320), the plugin will not deal with account names containing whitespace. (accounts containing whitespace were not anticipated).

This PR is an attempt to fix this. 