### PR TITLE
feat: wildcards in comment string #85

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -89,7 +89,10 @@ class Executor(RemoteExecutor):
         # generic part of a submission string:
         # we use a run_uuid as the job-name, to allow `--name`-based
         # filtering in the job status checks (`sacct --name` and `squeue --name`)
-        comment_str = f"{job.name}_{wildcard_str}"
+        if wildcard_str == "":
+            comment_str = f"rule_{job.name}"
+        else:
+            comment_str = f"rule{job.name}_wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -89,7 +89,7 @@ class Executor(RemoteExecutor):
         # generic part of a submission string:
         # we use a run_uuid as the job-name, to allow `--name`-based
         # filtering in the job status checks (`sacct --name` and `squeue --name`)
-        comment_str = f"{job.name} {wildcard_str}"
+        comment_str = f"{job.name}_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -89,9 +89,10 @@ class Executor(RemoteExecutor):
         # generic part of a submission string:
         # we use a run_uuid as the job-name, to allow `--name`-based
         # filtering in the job status checks (`sacct --name` and `squeue --name`)
+        comment_str = f"{job.name} {wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
-            f"--comment {job.name}"
+            f"--comment {comment_str}"
         )
 
         call += self.get_account_arg(job)

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -92,7 +92,7 @@ class Executor(RemoteExecutor):
         if wildcard_str == "":
             comment_str = f"rule_{job.name}"
         else:
-            comment_str = f"rule_{job.name}_wildcards_{wildcard_str}"
+            comment_str = f"rule_{job.name}__wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -89,7 +89,7 @@ class Executor(RemoteExecutor):
         # generic part of a submission string:
         # we use a run_uuid as the job-name, to allow `--name`-based
         # filtering in the job status checks (`sacct --name` and `squeue --name`)
-        comment_str = f"{job.name}__{wildcard_str}"
+        comment_str = f"{job.name} {wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -92,7 +92,7 @@ class Executor(RemoteExecutor):
         if wildcard_str == "":
             comment_str = f"rule_{job.name}"
         else:
-            comment_str = f"rule{job.name}_wildcards_{wildcard_str}"
+            comment_str = f"rule_{job.name};wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -92,7 +92,7 @@ class Executor(RemoteExecutor):
         if wildcard_str == "":
             comment_str = f"rule_{job.name}"
         else:
-            comment_str = f"rule_{job.name};wildcards_{wildcard_str}"
+            comment_str = f"rule_{job.name}_wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -89,7 +89,7 @@ class Executor(RemoteExecutor):
         # generic part of a submission string:
         # we use a run_uuid as the job-name, to allow `--name`-based
         # filtering in the job status checks (`sacct --name` and `squeue --name`)
-        comment_str = f"{job.name} {wildcard_str}"
+        comment_str = f"{job.name}__{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -92,7 +92,7 @@ class Executor(RemoteExecutor):
         if wildcard_str == "":
             comment_str = f"rule_{job.name}"
         else:
-            comment_str = f"rule_{job.name}__wildcards_{wildcard_str}"
+            comment_str = f"rule_{job.name}_wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
             f"--comment {comment_str}"


### PR DESCRIPTION
Small change to include wildcards in the comment strings (re #85). 

I tested it locally on my Slurm instance, and it works well. 

I also prefixed the rule name with `rule_` to match the formatting of the slurm log path. 

Cheers,
Mitchell
