### PR TITLE
feat: will reject jobs, which attempt setting job names by 'slurm_extra'

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -495,10 +495,10 @@ class Executor(RemoteExecutor):
         jobname = re.compile(r"--job-name[=?|\s+]|-J\s?")
         if re.search(jobname, job.resources.slurm_extra):
             raise WorkflowError(
-                "The --job-name option is not allowed in the 'slurm_extra' "
+                "The '--job-name' option is not allowed in the 'slurm_extra' "
                 "parameter. The job name is set by snakemake and must not be "
-                "overwritten. It is internally used to check the stati of the "
-                "all submitted jobs by this workflow."
+                "overwritten. It is internally used to check the stati of all "
+                "submitted jobs by this workflow."
                 "Please consult the documentation if you are unsure how to "
                 "query the status of your jobs."
             )

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -135,7 +135,7 @@ class Executor(RemoteExecutor):
         call += f" --cpus-per-task={get_cpus_per_task(job)}"
 
         if job.resources.get("slurm_extra"):
-            self.check_slurm_extra()
+            self.check_slurm_extra(job)
             call += f" {job.resources.slurm_extra}"
 
         exec_job = self.format_job_exec(job)
@@ -482,7 +482,7 @@ class Executor(RemoteExecutor):
         )
         return ""
 
-    def check_slurm_extra(self):
+    def check_slurm_extra(self, job):
         jobname = re.compile(r"--job-name[=?|\s+]|-J\s?")
         if re.search(jobname, job.resources.slurm_extra):
             raise WorkflowError(


### PR DESCRIPTION
Occasionally, users reported that their attempt to overwrite SLURM job names leads to faulty behaviour (job status does not get queried properly, and a workflow will stall). This is understandable from the code and documented accordingly.

The PR checks for the job status using a regex - simple string matching might be too error-prone (e.g. "-J" can be part of a wildcard).

The decision is here, that the workflow will abort (raising WorkflowError and explaining and pointing to the docs).

Please check whether this is "likeable".

I do not know how to implement a test. The other executors leave me clueless. 