### PR TITLE
Make sure sbatch receives --comments correctly

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -130,7 +130,7 @@ class Executor(RemoteExecutor):
             comment_str = f"rule_{job.name}_wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
-            f"--comment {comment_str}"
+            f"--comment `{comment_str}`"
         )
 
         call += self.get_account_arg(job)

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -130,7 +130,7 @@ class Executor(RemoteExecutor):
             comment_str = f"rule_{job.name}_wildcards_{wildcard_str}"
         call = (
             f"sbatch --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
-            f"--comment `{comment_str}`"
+            f"--comment=`{comment_str}`"
         )
 
         call += self.get_account_arg(job)


### PR DESCRIPTION
I’ve resolved the issue, and it turns out that the problem was not with the account and partition not being input correctly. The actual issue was with the `--comment` parameter in the sbatch command. In the original `__init__.py` file, line 133 was `f"--comment {comment_str}"`. It’s crucial to note that `comment_str` needs to be enclosed in quotes. If this is not done, it might cause sbatch to misinterpret `comment_str`, leading to the -A and -p parameters (which specify the account and partition) being incorrectly associated with the `--comment` parameter. This would result in the following WorkflowError:

> SLURM job submission failed. The error message was sbatch: error: invalid account or account/partition combination specified
> sbatch: error: Batch job submission failed: Unspecified error

To fix the issue, the line in the __init__.py file should be modified to ensure that comment_str is properly quoted,  like so:
```f"--comment=`{comment_str}`"```
Note: it’s important to use the` = `sign to properly assign the value to the `--comment` option in the sbatch command. 

By making this change, sbatch will correctly interpret the --comment parameter and subsequent -A and -p parameters, allowing the job to be submitted without errors.

The final command passed to sbatch would then be correctly formatted, like so:
```sbatch --comment=`Y{comment_str}` -A your_account -p your_partition ...```
