### PR TITLE
fix: add --parsable to sbatch call for a more robust output parsing

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -119,7 +119,7 @@ You can use the following specifications:
 | `--ntasks`     | `tasks`    | number of concurrent tasks / ranks    |
 | `--cpus-per-task`       | `cpus_per_task`      | number of cpus per task (in case of SMP, rather use `threads`)   |
 | `--nodes` | `nodes`    | number of nodes                       |
-| `--clusters` | `cluster` | comma separated string of clusters |
+| `--clusters` | `clusters` | comma separated string of clusters |
 
 Each of these can be part of a rule, e.g.:
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -130,7 +130,11 @@ class Executor(RemoteExecutor):
         else:
             comment_str = f"rule_{job.name}_wildcards_{wildcard_str}"
         call = (
-            f"sbatch --parsable --job-name {self.run_uuid} --output {slurm_logfile} --export=ALL "
+            f"sbatch "
+            f"--parsable "
+            f"--job-name {self.run_uuid} "
+            f"--output {slurm_logfile} "
+            f"--export=ALL "
             f"--comment {comment_str}"
         )
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -208,7 +208,7 @@ class Executor(RemoteExecutor):
         # "Submitted batch job <id> on cluster <name>" by default, but with the
         # --parsable option it simply yields "<id>;<name>".
         # To extract the job id we split by semicolon and take the first element
-        # (this also works if not cluster name was provided)
+        # (this also works if no cluster name was provided)
         slurm_jobid = out.split(";")[0]
         slurm_logfile = slurm_logfile.replace("%j", slurm_jobid)
         self.logger.info(


### PR DESCRIPTION
Following discussion in https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/121#issuecomment-2270905243 , this implementation seems more robust than match a word with only numbers (which could break in future versions of slurm, or if a cluster name is made of only numbers).