### PR TITLE
feat: added requeue option to client

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -40,7 +40,7 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": False,
         },
     )
-    requeue: Optional[bool] = field(
+    requeue: bool = field(
         default=False,
         metadata={
             "help": """

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -45,7 +45,8 @@ class ExecutorSettings(ExecutorSettingsBase):
         metadata={
             "help": """
                     Allow requeuing preempted of failed jobs,
-                    if no cluster default.
+                    if no cluster default. Results in `sbatch ... --requeue ...`
+                    This flag has no effect, if not set.
                     """,
             "env_var": False,
             "required": False,

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -152,7 +152,7 @@ class Executor(RemoteExecutor):
 
         call += self.get_account_arg(job)
         call += self.get_partition_arg(job)
-        
+
         if self.settings.requeue:
             call += " --requeue"
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -91,8 +91,6 @@ class Executor(RemoteExecutor):
         self._fallback_account_arg = None
         self._fallback_partition = None
         self._preemption_warning = False  # no preemption warning has been issued
-        # providing a short-hand, even if subsequent calls seem redundant
-        self.settings: ExecutorSettings = self.workflow.executor_settings
 
     def warn_on_jobcontext(self, done=None):
         if not done:
@@ -157,7 +155,7 @@ class Executor(RemoteExecutor):
         call += self.get_account_arg(job)
         call += self.get_partition_arg(job)
 
-        if self.settings.requeue:
+        if self.workflow.settings.requeue:
             call += " --requeue"
 
         if job.resources.get("clusters"):

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -40,6 +40,17 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": False,
         },
     )
+    requeue: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": """
+                    Allow requeuing preempted of failed jobs,
+                    if no cluster default.
+                    """,
+            "env_var": False,
+            "required": False,
+        },
+    )
 
 
 # Required:
@@ -141,6 +152,9 @@ class Executor(RemoteExecutor):
 
         call += self.get_account_arg(job)
         call += self.get_partition_arg(job)
+        
+        if self.settings.requeue:
+            call += " --requeue"
 
         if job.resources.get("clusters"):
             call += f" --clusters {job.resources.clusters}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -155,7 +155,7 @@ class Executor(RemoteExecutor):
         call += self.get_account_arg(job)
         call += self.get_partition_arg(job)
 
-        if self.workflow.settings.requeue:
+        if self.workflow.executor_settings.requeue:
             call += " --requeue"
 
         if job.resources.get("clusters"):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,12 +2,19 @@ from typing import Optional
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 
+from snakemake_executor_plugin_slurm import ExecutorSettings
 
-class TestWorkflowsBase(snakemake.common.tests.TestWorkflowsLocalStorageBase):
+
+class TestWorkflows(snakemake.common.tests.TestWorkflowsLocalStorageBase):
     __test__ = True
 
     def get_executor(self) -> str:
         return "slurm"
 
     def get_executor_settings(self) -> Optional[ExecutorSettingsBase]:
-        return None
+        return ExecutorSettings()
+
+
+class TestWorkflowsRequeue(TestWorkflows):
+    def get_executor_settings(self) -> Optional[ExecutorSettingsBase]:
+        return ExecutorSettings(requeue=True)


### PR DESCRIPTION
added option for users to indicate the sbatch requeue flag if the cluster configuration does no re-queuing on default

this is a boolean flag. We wait for the interface_plugin to be fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new option to allow requeuing of preempted or failed jobs in the job execution settings.
	- Added a `--requeue` flag to the job submission command for enhanced control over job handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->