### PR TITLE
docs: requeue

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -162,7 +162,8 @@ set-resources:
 
 ### Additional Command Line Flags
 
-This plugin defines additional command line flags. As always the can be used on the command line or in a profile.
+This plugin defines additional command line flags.
+As always, these can be set on the command line or in a profile.
 
 | Flag        | Meaning  |
 |-------------|----------|

--- a/docs/further.md
+++ b/docs/further.md
@@ -297,7 +297,7 @@ snakemake ... --rerun-incomplete
 snakemake ... --ri
 ```
 
-The "requeue" option allows jobs to be resubmitted automatically if they fail or are preempted. This might be the default on your cluster, already. You can check your cluster's requeue settings with 
+The "requeue" option allows jobs to be resubmitted automatically if they fail or are preempted. This is similar to Snakemake's `--retries`, except a SLURM job will not be considered failed and priority may be accumulated during pending. This might be the default on your cluster, already. You can check your cluster's requeue settings with 
 
 ```console
 scontrol show config | grep Requeue

--- a/docs/further.md
+++ b/docs/further.md
@@ -281,7 +281,7 @@ export SNAKEMAKE_PROFILE="$HOME/.config/snakemake"
 
 ==This is ongoing development. Eventually you will be able to annotate different file access patterns.==
 
-## <a name="retries"></a> Retries - Or Trying again when a Job failed
+## Retries - Or Trying again when a Job failed
 
 Some cluster jobs may fail. In this case Snakemake can be instructed to try another submit before the entire workflow fails, in this example up to 3 times:
 

--- a/docs/further.md
+++ b/docs/further.md
@@ -167,7 +167,7 @@ As always, these can be set on the command line or in a profile.
 
 | Flag        | Meaning  |
 |-------------|----------|
-| `--slurm_init_seconds_before_status_checks`| will modify the default time (40 seconds) before the initial status check - usefull for development purposes|
+| `--slurm_init_seconds_before_status_checks`| modify time before initial job status check; the default of 40 seconds avoids load on querying slurm databases, but shorter wait times are for example useful during workflow development |
 | `--slurm_requeue` | allows jobs to be resubmitted automatically if they fail or are preempted. See the [section "retries" for details](#retries)|
 
 ## Multicluster Support

--- a/docs/further.md
+++ b/docs/further.md
@@ -160,6 +160,15 @@ set-resources:
         cpus_per_task: 40
 ```
 
+### Additional Command Line Flags
+
+This plugin defines additional command line flags. As always the can be used on the command line or in a profile.
+
+| Flag        | Meaning  |
+|-------------|----------|
+| `--slurm_init_seconds_before_status_checks`| will modify the default time (40 seconds) before the initial status check - usefull for development purposes|
+| `--slurm_requeue` | allows jobs to be resubmitted automatically if they fail or are preempted. See the [section "retries" for details](#retries)|
+
 ## Multicluster Support
 
 For reasons of scheduling multicluster support is provided by the `clusters` flag in resources sections. Note, that you have to write `clusters`, not `cluster`! 
@@ -271,7 +280,7 @@ export SNAKEMAKE_PROFILE="$HOME/.config/snakemake"
 
 ==This is ongoing development. Eventually you will be able to annotate different file access patterns.==
 
-## Retries - Or Trying again when a Job failed
+## <a name="retries"></a> Retries - Or Trying again when a Job failed
 
 Some cluster jobs may fail. In this case Snakemake can be instructed to try another submit before the entire workflow fails, in this example up to 3 times:
 
@@ -282,7 +291,19 @@ snakemake --retries=3
 If a workflow fails entirely (e.g. when there are cluster failures), it can be resumed as any other Snakemake workflow:
 
 ```console
-snakemake --rerun-incomplete
+snakemake ... --rerun-incomplete
+```
+
+The "requeue" option allows jobs to be resubmitted automatically if they fail or are preempted. This might be the default on your cluster, already. You can check your cluster's requeue settings with 
+
+```console
+scontrol show config | grep Requeue
+```
+
+This requeue feature is integrated into the SLURM submission command, adding the --requeue parameter to allow requeuing after node failure or preemption using:
+
+```console
+snakemake --slurm-requeue ...
 ```
 
 To prevent failures due to faulty parameterization, we can dynamically adjust the runtime behaviour:

--- a/docs/further.md
+++ b/docs/further.md
@@ -203,7 +203,7 @@ rule ...:
        "bio/VinaLC"
 ```
 
-This will, internally, trigger a `module load bio`/VinaLC` immediately prior to execution. 
+This will, internally, trigger a `module load bio VinaLC` immediately prior to execution. 
 
 Note, that 
 - environment modules are best specified in a configuration file.

--- a/docs/further.md
+++ b/docs/further.md
@@ -292,6 +292,8 @@ If a workflow fails entirely (e.g. when there are cluster failures), it can be r
 
 ```console
 snakemake ... --rerun-incomplete
+# or the short-hand version
+snakemake ... --ri
 ```
 
 The "requeue" option allows jobs to be resubmitted automatically if they fail or are preempted. This might be the default on your cluster, already. You can check your cluster's requeue settings with 


### PR DESCRIPTION
only documenting what is new in v0.11.0 (see #152 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new command line flags for the SLURM executor plugin: `--slurm_init_seconds_before_status_checks` and `--slurm_requeue`.
- **Documentation**
	- Expanded guidance on job resubmission and retries, enhancing clarity on the use of `--retries` and `--slurm-requeue`.
	- Improved overall structure of the documentation for better understanding of job configuration and resource specifications.
	- Minor formatting corrections made for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->