### PR TITLE
Respect GPU resource specifications

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -185,6 +185,16 @@ class Executor(RemoteExecutor):
 
         if job.resources.get("nodes", False):
             call += f" --nodes={job.resources.get('nodes', 1)}"
+        
+        gpu_count = job.resources.get("gpu", job.resources.get("nvidia_gpu", -1))
+        if gpu_count != -1:
+            call += f" --gres=gpu:{gpu_count}"
+
+            if job.resources.get("gpu_model"):
+                gpu = job.resources.gpu_model
+                if gpu[:7] == "nvidia-":
+                    gpu = gpu[7:]
+                call += ":" + gpu
 
         # fixes #40 - set ntasks regardless of mpi, because
         # SLURM v22.05 will require it for all jobs

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -188,13 +188,13 @@ class Executor(RemoteExecutor):
         
         gpu_count = job.resources.get("gpu", job.resources.get("nvidia_gpu", -1))
         if gpu_count != -1:
-            call += f" --gres=gpu:{gpu_count}"
-
             if job.resources.get("gpu_model"):
                 gpu = job.resources.gpu_model
-                if gpu[:7] == "nvidia-":
+                if gpu.startswith("nvidia-"):
                     gpu = gpu[7:]
-                call += ":" + gpu
+                call += f" --gres=gpu:{gpu}:{gpu_count}"
+            else:
+                call += f" --gres=gpu:{gpu_count}"
 
         # fixes #40 - set ntasks regardless of mpi, because
         # SLURM v22.05 will require it for all jobs


### PR DESCRIPTION
Snakemake supports specification of required GPU resources in the Snakefile, i.e.

```
resources:
   nvidia_gpu: 1
```

Before this patch, slurm executor ignored these specifications and unless the user manually made sure this doesn't happen, the jobs would run on CPU nodes.
This is relatively easy to fix, because like Snakemake, SLURM supports per-job GPU resource specification.
This patch ensures that GPU requirements from the Snakefile are relayed to SLURM via

```
sbatch --gres:gpu
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced job submission logic to support GPU resource specifications.
	- Updated submission commands to include GPU count and model when applicable.
	- Improved task setting for SLURM jobs to comply with version 22.05 requirements.

- **Bug Fixes**
	- Refined error handling during job submission for clearer feedback on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->