### PR TITLE
fix: sshare testing as an alternative to sacctmgr account tests

### DIFF
--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -21,7 +21,7 @@ jobs:
           timeout_minutes: 2
           max_attempts: 3
           command: |
-                     curl -X POST -H "Authorization: Bearer ${{ secrets.MASTODON_ACCESS_TOKEN }}" \
+                     curl -X POST -H "Authorization: Bearer ${{ secrets.MASTODONBOT }}" \
                      -F "status=New release in Snakemake project '${{ github.event.repository.full_name }}' for pull request '#${{ github.event.pull_request.number }}' merged: '${{ github.event.pull_request.title }}'. Get the latest release from #Bioconda or #Pypi." \
                      https://fediscience.org/api/v1/statuses \
                      -w "\nResponse code: %{http_code}\n" \

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -555,10 +555,15 @@ We leave it to SLURM to resume your job(s)"""
                 cmd, shell=True, text=True, stderr=subprocess.PIPE
             )
         except subprocess.CalledProcessError as e:
-            raise WorkflowError(
-                f"Unable to test the validity of the given or guessed SLURM account "
-                f"'{account}' with sacctmgr: {e.stderr}"
-            )
+            sacctmgr_report = f"Unable to test the validity of the given or guessed SLURM account '{account}' with sacctmgr: {e.stderr}."
+            try:
+                cmd = "sshare -U --format Account --noheader"
+                accounts = subprocess.check_output(
+                    cmd, shell=True, text=True, stderr=subprocess.PIPE
+                )
+            except subprocess.CalledProcessError as e:
+                sshare_report = "Unable to test the validity of the given or guessed SLURM account '{account}' with sshare: {e.stderr}."
+                raise WorkflowError(sacctmgr_report + " - and - " + sshare_report)
 
         # The set() has been introduced during review to eliminate
         # duplicates. They are not harmful, but disturbing to read.

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -647,7 +647,10 @@ We leave it to SLURM to resume your job(s)"""
                     "Unable to test the validity of the given or guessed"
                     f" SLURM account '{account}' with sshare: {e2.stderr}."
                 )
-                raise WorkflowError(f"{sacctmgr_report} {sshare_report}")
+                raise WorkflowError(
+                    f"The 'sacctmgr' reported: '{sacctmgr_report}' "
+                    f"and likewise 'sshare' reported: '{sshare_report}'."
+                )
 
         # The set() has been introduced during review to eliminate
         # duplicates. They are not harmful, but disturbing to read.

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -555,14 +555,20 @@ We leave it to SLURM to resume your job(s)"""
                 cmd, shell=True, text=True, stderr=subprocess.PIPE
             )
         except subprocess.CalledProcessError as e:
-            sacctmgr_report = f"Unable to test the validity of the given or guessed SLURM account '{account}' with sacctmgr: {e.stderr}."
+            sacctmgr_report = (
+                "Unable to test the validity of the given or guessed "
+                f"SLURM account '{account}' with sacctmgr: {e.stderr}."
+            )
             try:
                 cmd = "sshare -U --format Account --noheader"
                 accounts = subprocess.check_output(
                     cmd, shell=True, text=True, stderr=subprocess.PIPE
                 )
-            except subprocess.CalledProcessError as e:
-                sshare_report = "Unable to test the validity of the given or guessed SLURM account '{account}' with sshare: {e.stderr}."
+            except subprocess.CalledProcessError as e2:
+                sshare_report = (
+                    "Unable to test the validity of the given or guessed"
+                    f" SLURM account '{account}' with sshare: {e2.stderr}."
+                )
                 raise WorkflowError(sacctmgr_report + " - and - " + sshare_report)
 
         # The set() has been introduced during review to eliminate

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -647,7 +647,7 @@ We leave it to SLURM to resume your job(s)"""
                     "Unable to test the validity of the given or guessed"
                     f" SLURM account '{account}' with sshare: {e2.stderr}."
                 )
-                raise WorkflowError(sacctmgr_report + " - and - " + sshare_report)
+                raise WorkflowError(f"{sacctmgr_report} {sshare_report}")
 
         # The set() has been introduced during review to eliminate
         # duplicates. They are not harmful, but disturbing to read.


### PR DESCRIPTION
Addresses issue #177 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in account validation for SLURM, providing more informative error messages.
	- Implemented a fallback mechanism to verify SLURM account validity through an additional command.
- **Chores**
	- Updated the authorization token in the GitHub Actions workflow for posting to Mastodon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->