### PR TITLE
fix: mastodonbot

### DIFF
--- a/.github/workflows/post_to_mastodon.sh
+++ b/.github/workflows/post_to_mastodon.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Extract version from PR title passed as environment variable
-version="${PR_TITLE##* }"
+# Extract version from PR tag passed as environment variable
+version="${PR_TITLE#v}"
 
 # Validate version format
 if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -1,7 +1,7 @@
 name: Post to Mastodon on PR Merge
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     types:

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -23,5 +23,5 @@ jobs:
           max_attempts: 3
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
-            export PR_TITLE="${{ github.event.release.tag_name#v }}"
+            export PR_TITLE="${{ github.event.release.tag_name }}"
             $GITHUB_WORKSPACE/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -23,5 +23,5 @@ jobs:
           max_attempts: 3
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
-            export PR_TITLE="${{ github.event.release.tag_name }}"
+            export PR_TITLE="${{ github.event.release.tag_name#v }}"
             $GITHUB_WORKSPACE/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -15,8 +15,8 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Post to Mastodon
-        uses: actions/checkout@v4
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 2

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -24,4 +24,4 @@ jobs:
             git checkout ${{ github.event.pull_request.head.sha }}
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
             export PR_TITLE="${{ github.event.pull_request.title }}"
-            ./post_to_mastodon.sh
+            $(pwd)/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Mastodon
+        uses: actions/checkout@v4
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 2
           max_attempts: 3
           command: |
-            git checkout ${{ github.event.pull_request.head.sha }}
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
-            export PR_TITLE="${{ github.event.pull_request.title }}"
-            $(pwd)/post_to_mastodon.sh
+            export PR_TITLE="${{ github.event.release.tag_name }}"
+            $GITHUB_WORKSPACE/post_to_mastodon.sh


### PR DESCRIPTION
attempt to fix the mastodon publisher:

- that the bot does not post on merged pull request, but only on releases (it used to publish the merge and the release)
- that the script is found (./post_to_mastodon.sh does not seem to work, perhaps $(pwd)/post_to_mastodon.sh will?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for Mastodon posting.
	- Modified workflow trigger to run on push to the main branch after a pull request merge.
	- Changed environment variable to use release tag name instead of pull request title.
	- Added a step to check out the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->