### PR TITLE
fix: ci runner ought to start now upon merge to main

### DIFF
--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -1,11 +1,11 @@
 name: Post to Mastodon on PR Merge
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     types:
       - closed
+    branches:
+      - main
 
 permissions:
   pull-requests: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to trigger Mastodon posting on pull request closure for the main branch
	- Refined workflow event configuration to improve automation precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->