### PR TITLE
fix: path to access the posting script

### DIFF
--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -24,4 +24,4 @@ jobs:
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
             export PR_TITLE="${{ github.event.release.tag_name }}"
-            $GITHUB_WORKSPACE/post_to_mastodon.sh
+            $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh


### PR DESCRIPTION
see title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow script path for Mastodon posting mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->