### PR TITLE
fix: path to posting script

### DIFF
--- a/.github/workflows/post_to_mastodon.sh
+++ b/.github/workflows/post_to_mastodon.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Extract version from PR tag passed as environment variable
-version="${PR_TITLE#v}"
+version="${PR_TITLE##* }"
 
 # Validate version format
 if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/post_to_mastodon.sh
+++ b/.github/workflows/post_to_mastodon.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # Extract version from PR tag passed as environment variable
+if [ -z "${PR_TITLE}" ]; then # apparently unset, workflow broken?
+    echo "Error: 'PR_TITLE' environemnt variable is not set."
+    exit 1
+fi
 version="${PR_TITLE##* }"
 
 # Validate version format
@@ -15,15 +19,14 @@ changelog="https://github.com/snakemake/snakemake-executor-plugin-slurm/releases
 # Maximum character limit for Mastodon posts (on Fediscience: 1500 characters)
 MAX_TOOT_LENGTH=1500
 
-
 read -d '\n' message << EndOfText
-Beep, Beep - I am your friendly #Snakemake release announcement bot
+Beep, Beep - I am your friendly #Snakemake release announcement bot.
 
 There is a new release of the Snakemake executor for #SLURM on #HPC systems. Its version is '${version}'!
 
 See ${changelog//\'/\\\'} for details.
 
-Give us some time and you will automatically find it on #Bioconda and #Pypi.
+Give us some time and you will automatically find the plugin on #Bioconda and #Pypi.
 
 If you want to discuss the release you will find the maintainers here on Mastodon!
 @rupdecat@fediscience.org and @johanneskoester@fosstodon.org

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -23,6 +23,6 @@ jobs:
           max_attempts: 3
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
-            export PR_TITLE="${{ github.event.release.tag_name }}"
+            export PR_TITLE="${{ github.event.pull_request.title }}"
             chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh
             $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -24,4 +24,5 @@ jobs:
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
             export PR_TITLE="${{ github.event.release.tag_name }}"
+            chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh
             $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -24,4 +24,4 @@ jobs:
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
             export PR_TITLE="${{ github.event.release.tag_name }}"
-            $GITHUB_ACTION_PATH/post_to_mastodon.sh
+            $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -24,4 +24,4 @@ jobs:
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
             export PR_TITLE="${{ github.event.release.tag_name }}"
-            $GITHUB_WORKSPACE/post_to_mastodon.sh
+            $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -24,4 +24,4 @@ jobs:
           command: |
             export MASTODONBOT="${{ secrets.MASTODONBOT }}"
             export PR_TITLE="${{ github.event.release.tag_name }}"
-            $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh
+            $GITHUB_ACTION_PATH/post_to_mastodon.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use the pull request title for posting to Mastodon.
	- Made the Mastodon post script executable.
	- Added validation for the pull request title in the posting script.
	- Improved version extraction logic for enhanced flexibility in input formats.
	- Revised announcement message for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->