### PR TITLE
fix: ci runner ought to start now upon merge to main

### DIFF
--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   post_to_mastodon:
     if: |
-      github.event.pull_request.merged == true &&
+      ${{ github.event.pull_request.merged }} &&
       (contains(github.event.pull_request.title, 'release') || contains(github.event.pull_request.title, ' v') || contains(github.event.pull_request.title, 'version'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -1,11 +1,11 @@
 name: Post to Mastodon on PR Merge
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     types:
       - closed
+    branches:
+      - main
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
again, because the last PR (#189 ) did not start, see https://github.com/snakemake/snakemake-executor-plugin-slurm/actions/runs/12902576814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow syntax for Mastodon post job
	- Improved conditional expression formatting in workflow configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->