### PR TITLE
feat: disallowing blank reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
simply disallowing blank issue reports. Too much to and fro before action can occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub issue template configuration to prevent creation of blank issues
  - Enforced structured issue reporting by requiring predefined templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->