### PR TITLE
fix: initializing self.slurm_logdir

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -122,7 +122,11 @@ class Executor(RemoteExecutor):
         self._fallback_account_arg = None
         self._fallback_partition = None
         self._preemption_warning = False  # no preemption warning has been issued
-        self.slurm_logdir = None
+        self.slurm_logdir = (
+            Path(self.workflow.executor_settings.logdir)
+            if self.workflow.executor_settings.logdir
+            else Path(".snakemake/slurm_logs").resolve()
+        )
         atexit.register(self.clean_old_logs)
 
     def clean_old_logs(self) -> None:
@@ -179,12 +183,6 @@ class Executor(RemoteExecutor):
             wildcard_str = "_".join(job.wildcards) if job.wildcards else ""
         except AttributeError:
             wildcard_str = ""
-
-        self.slurm_logdir = (
-            Path(self.workflow.executor_settings.logdir)
-            if self.workflow.executor_settings.logdir
-            else Path(".snakemake/slurm_logs").resolve()
-        )
 
         self.slurm_logdir.mkdir(parents=True, exist_ok=True)
         slurm_logfile = self.slurm_logdir / group_or_rule / wildcard_str / "%j.log"


### PR DESCRIPTION
setting `self.slurm_logdir` in `post_init`, else starts without something… to do, will encounter uninitialized `self.slurm_logdir attribute

This PR ought to fix #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced SLURM log directory management
  - Added flexibility for custom log directory configuration
  - Simplified log directory initialization process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->