### PR TITLE
fix: missing quotes for the slurm comment

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -208,7 +208,7 @@ class Executor(RemoteExecutor):
             f"--job-name {self.run_uuid} "
             f"--output '{slurm_logfile}' "
             f"--export=ALL "
-            f"--comment {comment_str}"
+            f"--comment '{comment_str}'"
         )
 
         call += self.get_account_arg(job)


### PR DESCRIPTION
Snakemake does not correctly escape the comment it passes to slurm. When a wildcard contains for example a `(` this will lead to errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Minor internal updates have been deployed to streamline how job submission commands are assembled. These refinements maintain the current functionality and user experience without introducing any visible changes.

- **Refactor**
  - Enhanced internal handling of command formatting during job submissions to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->