### PR TITLE
fix: logdir misconstruct when leading slash in wildcard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["snakemake", "plugin", "executor", "cluster", "slurm"]
 python = "^3.11"
 snakemake-interface-common = "^1.13.0"
 snakemake-interface-executor-plugins = "^9.1.1"
-snakemake-executor-plugin-slurm-jobstep = "^0.2.0"
+snakemake-executor-plugin-slurm-jobstep = "^0.3.0"
 throttler = "^1.2.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -180,7 +180,7 @@ class Executor(RemoteExecutor):
         group_or_rule = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
 
         try:
-            wildcard_str = "_".join(job.wildcards) if job.wildcards else ""
+            wildcard_str = "_".join(job.wildcards).replace("/", "_") if job.wildcards else ""
         except AttributeError:
             wildcard_str = ""
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -26,7 +26,7 @@ from snakemake_interface_executor_plugins.jobs import (
     JobExecutorInterface,
 )
 from snakemake_interface_common.exceptions import WorkflowError
-from snakemake_executor_plugin_slurm_jobstep import get_cpus_per_task
+from snakemake_executor_plugin_slurm_jobstep import get_cpu_setting
 
 from .utils import delete_slurm_environment, delete_empty_dirs
 
@@ -261,7 +261,7 @@ class Executor(RemoteExecutor):
                     "Probably not what you want."
                 )
 
-        call += f" --cpus-per-task={get_cpus_per_task(job)}"
+        call += f" --cpus-per-task={get_cpu_setting(job)}"
 
         if job.resources.get("slurm_extra"):
             self.check_slurm_extra(job)

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -180,7 +180,9 @@ class Executor(RemoteExecutor):
         group_or_rule = f"group_{job.name}" if job.is_group() else f"rule_{job.name}"
 
         try:
-            wildcard_str = "_".join(job.wildcards).replace("/", "_") if job.wildcards else ""
+            wildcard_str = (
+                "_".join(job.wildcards).replace("/", "_") if job.wildcards else ""
+            )
         except AttributeError:
             wildcard_str = ""
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,11 @@
+import os
 from typing import Optional
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from unittest.mock import MagicMock
 import pytest
 
-from snakemake_executor_plugin_slurm import ExecutorSettings
+from snakemake_executor_plugin_slurm import ExecutorSettings, Executor
 from snakemake_executor_plugin_slurm.utils import set_gres_string
 from snakemake_interface_common.exceptions import WorkflowError
 
@@ -113,7 +114,10 @@ class TestGresString:
 
 
 class TestWildcardsWithSlashes(snakemake.common.tests.TestWorkflowsLocalStorageBase):
-    """Test handling of wildcards with slashes to ensure log directories are correctly constructed."""
+    """
+    Test handling of wildcards with slashes to ensure log directories are
+    correctly constructed.
+    """
 
     __test__ = True
 
@@ -124,7 +128,10 @@ class TestWildcardsWithSlashes(snakemake.common.tests.TestWorkflowsLocalStorageB
         return ExecutorSettings(logdir="test_logdir")
 
     def test_wildcard_slash_replacement(self):
-        """Test that slashes in wildcards are correctly replaced with underscores in log directory paths."""
+        """
+        Test that slashes in wildcards are correctly replaced with
+        underscores in log directory paths.
+        """
 
         # Create a mock job with wildcards containing slashes
         class MockJob:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,11 +1,10 @@
-import os
 from typing import Optional
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from unittest.mock import MagicMock
 import pytest
 
-from snakemake_executor_plugin_slurm import ExecutorSettings, Executor
+from snakemake_executor_plugin_slurm import ExecutorSettings
 from snakemake_executor_plugin_slurm.utils import set_gres_string
 from snakemake_interface_common.exceptions import WorkflowError
 


### PR DESCRIPTION
This is a minor fix, which addresses issue #214: A slurm logdirectory will start with `/` if a wildcard starts with `/`. After discussing with @johanneskoester , allowing for slashes in wildcards should not be an issue. Hence, the escape in this PR. Also, https://github.com/snakemake/snakemake/issues/3318 can be considered solved. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality for requesting GPU resources in SLURM jobs, with detailed documentation on methods for specifying GPUs and associated CPU settings.

- **Bug Fixes**
  - Improved handling of job resource specifications to enforce clarity between GRES and GPU inputs, preventing potential conflicts.

- **Dependencies**
  - Updated the version of the `snakemake-executor-plugin-slurm-jobstep` dependency from `^0.2.0` to `^0.3.0`, which may include enhancements and bug fixes.

- **Documentation**
  - Added a new section on "GPU Jobs" outlining how to request GPU resources with examples and clarifications on resource specifications.

- **Tests**
  - Removed unnecessary import from test files, streamlining the test code without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->