### PR TITLE
ci: add release-please token to release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
         id: release
         with:
           release-type: python
+          token: ${{ secrets.RELEASE_PLEASE_PR_CI_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should enable the CI tests to run on release-please generated pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated release process to use secure token authentication, ensuring smoother and more reliable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->