### PR TITLE
feat: tolerant status checks

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -388,7 +388,7 @@ class Executor(RemoteExecutor):
 
         sacct_query_durations = []
 
-        status_attempts = self.workflow.executor_settings.status_attemps
+        status_attempts = self.workflow.executor_settings.status_attempts
         self.logger.debug(
             f"Checking the status of {len(active_jobs)} active jobs "
             f"with {status_attempts} attempts."


### PR DESCRIPTION
The plugin ought to wait a bit, if a connection to the SLURM database cannot be established (the `sacct` command fails). 

This PR addresses issue report #207.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional integer field for configuring the number of attempts to query the status of active jobs, enhancing user control over job monitoring.
  - Enhanced system reliability by introducing an automatic retry mechanism for job status checks, improving overall monitoring stability.
  
- **Bug Fixes**
  - Improved error handling for job status checks, providing clearer logging for potential SLURM database issues and other errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->