### PR TITLE
fix: case insensitive matching of declared slurm account 

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -712,7 +712,7 @@ We leave it to SLURM to resume your job(s)"""
             )
             return ""
 
-        if account not in accounts:
+        if account.lower() not in accounts:
             raise WorkflowError(
                 f"The given account {account} appears to be invalid. Available "
                 f"accounts:\n{', '.join(accounts)}"


### PR DESCRIPTION
Hi :)

I noticed that accounts retrieved using `sshare -U --format Account --noheader` are always lower-cased. Slurm seems to accept both original (with upper-case letters) and lower-case account name while submitting jobs through sbatch. This quick edit ensure that the check for slurm account validity is performed regardless of the presence of uppercased letters, avoding WorkflowError raising in https://github.com/snakemake/snakemake-executor-plugin-slurm/blob/ed403c9685aab2f5147b9210f987d135725ccd95/snakemake_executor_plugin_slurm/__init__.py#L715-L719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved account validation to be case-insensitive, ensuring that input variations in letter casing no longer prevent successful authentication. This enhancement provides a smoother and more flexible user experience when entering account details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->