### PR TITLE
fix: Increase account charecter limit

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -653,7 +653,7 @@ We leave it to SLURM to resume your job(s)"""
         """
         tests whether the given account is registered, raises an error, if not
         """
-        cmd = "sshare -U --format Account --noheader"
+        cmd = "sshare -U --format Account%256 --noheader"
         try:
             accounts = subprocess.check_output(
                 cmd, shell=True, text=True, stderr=subprocess.PIPE


### PR DESCRIPTION
I faced an issue where a long queue name is prepended with a +, which causes the test_account to fail. I recommend increasing the charecter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of SLURM accounts by updating the formatting of the account check command to ensure more consistent and reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->