### PR TITLE
fix: using latest fix for the announcement action

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Mastodon
-        uses: snakemake/mastodon-release-post-action@v1
+        uses: snakemake/mastodon-release-post-action@v1.0.2
         with:
           message: |
             Beep, Beep - I am your friendly #Snakemake release announcement bot.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow for announcing releases on Mastodon to use a newer version of the release post action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->