### PR TITLE
fix: mastodon secret used workflow, not action

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Mastodon
-        uses: snakemake/mastodon-release-post-action@v1.0.3
+        uses: snakemake/mastodon-release-post-action@v1.0.4
 
         with:
           access-token: ${{ secrets.MASTODONBOT }}

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: snakemake/mastodon-release-post-action@v1.0.3
 
         with:
+          access-token: ${{ secrets.MASTODONBOT }}
           message: |
             Beep, Beep - I am your friendly #Snakemake release announcement bot.
             


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release announcement workflow to use an updated Mastodon integration and improved token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->