### PR TITLE
feat: attempt to gain full release notes posted on mastodon

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -15,21 +15,27 @@ jobs:
     if: "${{ contains(github.event.head_commit.message, 'chore(main): release') }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v2
       - name: Post to Mastodon
-        uses: snakemake/mastodon-release-post-action@v1.3.0
+        uses: snakemake/mastodon-release-post-action@v1.2.3
         with:
           access-token: ${{ secrets.MASTODONBOT }}
           pr-title: ${{ github.event.head_commit.message }}
           message: |
             Beep, Beep - I am your friendly #Snakemake release announcement bot.
             
-            There is a new release of the Snakemake executor for #SLURM on #HPC systems. Its version is {{ version }}!
+            There is a new release of the Snakemake executor for #SLURM on #HPC systems. Its version now is {{ version }}!
             
-            See {{ changelog }} for details.
+            Give us some time, and you will automatically find the plugin on #Bioconda and #Pypi.
             
-            Give us some time and you will automatically find the plugin on #Bioconda and #Pypi.
+            If you want to discuss the release, you will find the maintainers here on Mastodon!
+            @rupdecat and @johanneskoester@fosstodon.org
             
-            If you want to discuss the release you will find the maintainers here on Mastodon!
-            @rupdecat and @johanneskoester
+            If you discover any issues, please report them on {{ issue_url }}.
+
+            See {{ changelog }} for details. Here is the header of the changelog:
             
-            If you find any issues, please report them on {{ issue_url }}
+            ${{ steps.extract-release-notes.outputs.release_notes }}
+            


### PR DESCRIPTION
This PR should enable the post to mastodon action to publish the part of the Changelog describing the change related to the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the format of release announcements on Mastodon, including clearer version information, reordered details, and inline release notes.
  - Updated workflow steps for extracting and posting release notes.
  - Adjusted Mastodon posting action version for workflow stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->