### PR TITLE
feat: adding reservation flag

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -106,6 +106,14 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": False,
         },
     )
+    reservation: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "If set, the given reservation will be used for job submission.",
+            "env_var": False,
+            "required": False,
+        },
+    )
 
 
 # Required:
@@ -244,6 +252,9 @@ class Executor(RemoteExecutor):
 
         if self.workflow.executor_settings.requeue:
             call += " --requeue"
+
+        if self.workflow.executor_settings.reservation:
+            call += f" --reservation={self.workflow.executor_settings.reservation}"
 
         call += set_gres_string(job)
 


### PR DESCRIPTION
This PR adds a `--reservation` flag. Usually, for teaching, we recommend relying on SLURM's `magnetic` flag. This way, users will not need to specify a reservation. However, not all reservations can be made magnetic nor for all courses. Hence, the introduction of a new flag.