### PR TITLE
build: Do not pin numpy to 1.x; allow numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ snakemake-interface-common = "^1.13.0"
 snakemake-interface-executor-plugins = "^9.1.1"
 snakemake-executor-plugin-slurm-jobstep = "^0.3.0"
 pandas = "^2.2.3"
-numpy = "^1.26.4"
+numpy = ">=1.26.4, <3"
 throttler = "^1.2.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The `numpy` dependency added in 3cef6b7889c8ba09280f345bade3497b144bedc7 is SemVer-pinned to 1.x. Allow current `numpy` releases (2.x) as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the version range for the numpy dependency to allow any version from 1.26.4 up to, but not including, 3.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->