### PR TITLE
feat: make status and cancel command configurable

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -158,8 +158,8 @@ class ExecutorSettings(ExecutorSettingsBase):
             "help": "The command to query the status of SLURM jobs. "
             "This command should return one line for each job with "
             "<raw/main_job_id>|<long_status_string>."
-            "If no accounting is enabled, an alternative is:"
-            "squeue --states=all --format=%i\|%T --noheader --name {run_uuid}",
+            "If no accounting is enabled, an alternative is:",
+            # "squeue --states=all --format=%i|%T --noheader --name {run_uuid}",
             "env_var": False,
             "required": False,
         },
@@ -614,7 +614,7 @@ We leave it to SLURM to resume your job(s)"""
                 # about 30 sec, but can be longer in extreme cases.
                 # Under 'normal' circumstances, 'scancel' is executed in
                 # virtually no time.
-                scancel_command = self.workflow.executor_settings.canceland.format(jobids=jobids)
+                scancel_command = self.workflow.executor_settings.cancel_command.format(jobids=jobids)
 
                 subprocess.check_output(
                     scancel_command,


### PR DESCRIPTION
Slurms behavior with sacct and scancel (with specific options) changed when no accounting database is configured:

```
[supercomputer ~]# sacct 
Slurm accounting storage is disabled

[supercomputer ~]# scancel 123 --clusters=all
scancel: error: Problem talking to database
scancel: error: No clusters can be reached now. Contact your admin to resolve the problem.
scancel: fatal: Could not get cluster information
```

My Slurm version in use:
```
# scancel --version
slurm 24.05.4
```

## Slurm job status

For checking the job status an aequivalent commant to the current implementation can be run with squeue (given the Slurm config has sufficiently long, i.e. `MinJobAge=86400`).

Example an alternative status command:
```
$ squeue --format=%i\|%T --states=all --noheader --name b722e167-0559-4add-8c32-2fcc7aa80a62
3266|CANCELLED
3267|CANCELLED
[...]
```

## slurm job cancel
For the cancel command, I'd rather remove the `--clusters=all` flag, and make the default just to issue the cancel on the "local" cluster (with the option to override it). But I'm not an active Snakemake user, so the discussion about default settings is better left to someone else ;)

