### PR TITLE
fix: efficiency report jobsteps

### DIFF
--- a/snakemake_executor_plugin_slurm/efficiency_report.py
+++ b/snakemake_executor_plugin_slurm/efficiency_report.py
@@ -54,6 +54,7 @@ def parse_reqmem(reqmem, number_of_nodes=1):
         return mem_mb  # Default case (per CPU or total)
     return 0
 
+
 def get_sacct_data(run_uuid, logger):
     """Fetch raw sacct data for a workflow."""
     cmd = f"sacct --name={run_uuid} --parsable2 --noheader"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -31,12 +31,18 @@ class TestWorkflows(snakemake.common.tests.TestWorkflowsLocalStorageBase):
 def test_parse_sacct_data():
     from io import StringIO
 
-    test_data = """10294159|b10191d0-6985-4c3a-8ccb-aa7d23ebffc7|rule_bam_bwa_mem_mosdepth_simulate_reads|00:01:31|00:24.041|1|1||32000M
-10294159.batch|batch||00:01:31|00:03.292|1|1|71180K|
-10294159.0|python3.12||00:01:10|00:20.749|1|1|183612K|
-10294160|b10191d0-6985-4c3a-8ccb-aa7d23ebffc7|rule_bam_bwa_mem_mosdepth_simulate_reads|00:01:30|00:24.055|1|1||32000M
-10294160.batch|batch||00:01:30|00:03.186|1|1|71192K|
-10294160.0|python3.12||00:01:10|00:20.868|1|1|184352K|""".splitlines()
+    test_data = [
+        "10294159|b10191d0-6985-4c3a-8ccb-"
+        "aa7d23ebffc7|rule_bam_bwa_mem_mosdepth_"
+        "simulate_reads|00:01:31|00:24.041|1|1||32000M",
+        "10294159.batch|batch||00:01:31|00:03.292|1|1|71180K|",
+        "10294159.0|python3.12||00:01:10|00:20.749|1|1|183612K|",
+        "10294160|b10191d0-6985-4c3a-8ccb-"
+        "aa7d23ebffc7|rule_bam_bwa_mem_mosdepth_"
+        "simulate_reads|00:01:30|00:24.055|1|1||32000M",
+        "10294160.batch|batch||00:01:30|00:03.186|1|1|71192K|",
+        "10294160.0|python3.12||00:01:10|00:20.868|1|1|184352K|",
+    ]
     df = parse_sacct_data(
         lines=test_data, e_threshold=0.0, run_uuid="test", logger=None
     )


### PR DESCRIPTION
Fixes #337. 

This PR makes sure for each job in sacct output, only the jobstep is reported and that each record has rulename and memrequested. Also refactors efficiency report slightly to allow unit testing of parsing sacct output. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split the efficiency report into separate data-fetching and parsing stages for more reliable SLURM data handling.
  * Improved handling of job steps with inheritance of job metadata (rule names, requested memory) and robust CPU/memory efficiency calculations with low-efficiency warnings.

* **Tests**
  * Added a test verifying SLURM output parsing, metadata inheritance for job steps, and correct memory/efficiency reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->