### PR TITLE
fix: account lookup / test in multicluster environment

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -679,6 +679,8 @@ We leave it to SLURM to resume your job(s)"""
                 self.test_account(account)
             # sbatch only allows one account per submission
             # yield one after the other, if multiple were given
+            # we have to quote the account, because it might
+            # contain build-in shell commands - see issue #354
             for account in accounts:
                 yield f" -A {shlex.quote(account)}"
         else:
@@ -688,7 +690,7 @@ We leave it to SLURM to resume your job(s)"""
                 if account:
                     self.logger.warning(f"Guessed SLURM account: {account}")
                     self.test_account(f"{account}")
-                    self._fallback_account_arg = f" -A {account}"
+                    self._fallback_account_arg = f" -A {shlex.quote(account)}"
                 else:
                     self.logger.warning(
                         "Unable to guess SLURM account. Trying to proceed without."
@@ -711,7 +713,9 @@ We leave it to SLURM to resume your job(s)"""
                 self._fallback_partition = self.get_default_partition(job)
             partition = self._fallback_partition
         if partition:
-            return f" -p {partition}"
+            # we have to quote the partition, because it might
+            # contain build-in shell commands
+            return f" -p {shlex.quote(partition)}"
         else:
             return ""
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -307,7 +307,7 @@ class Executor(RemoteExecutor):
             "run_uuid": self.run_uuid,
             "slurm_logfile": slurm_logfile,
             "comment_str": comment_str,
-            "account": self.get_account_arg(job),
+            "account": next(self.get_account_arg(job)),
             "partition": self.get_partition_arg(job),
             "workdir": self.workflow.workdir_init,
         }

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -698,7 +698,7 @@ We leave it to SLURM to resume your job(s)"""
                     self._fallback_account_arg = (
                         ""  # no account specific args for sbatch
                     )
-            return self._fallback_account_arg
+            yield self._fallback_account_arg
 
     def get_partition_arg(self, job: JobExecutorInterface):
         """

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -726,6 +726,7 @@ We leave it to SLURM to resume your job(s)"""
         # first we need to test with sacctmgr because sshare might not
         # work in a multicluster environment
         cmd = f'sacctmgr -n -s list user "{os.environ["USER"]}" format=account%256'
+        sacctmgr_report = sshare_report = ""
         try:
             accounts = subprocess.check_output(
                 cmd, shell=True, text=True, stderr=subprocess.PIPE

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -677,13 +677,10 @@ We leave it to SLURM to resume your job(s)"""
                 # here, we check whether the given or guessed account is valid
                 # if not, a WorkflowError is raised
                 self.test_account(account)
-            # sbatch accepts a single --account; use the first valid token
-            selected = accounts[0]
-            if len(accounts) > 1:
-                self.logger.info(
-                    f"Multiple accounts provided ({accounts}); submitting with '{selected}'."
-                )
-            return f" -A {shlex.quote(selected)}"
+            # sbatch only allows one account per submission
+            # yield one after the other, if multiple were given
+            for account in accounts:
+                yield f" -A {shlex.quote(account)}"
         else:
             if self._fallback_account_arg is None:
                 self.logger.warning("No SLURM account given, trying to guess.")

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -670,7 +670,9 @@ We leave it to SLURM to resume your job(s)"""
         if job.resources.get("slurm_account"):
             # split the account upon ',' and whitespace, to allow
             # multiple accounts being given
-            accounts = [a for a in re.split(r"[,\s]+", job.resources.slurm_account) if a]
+            accounts = [
+                a for a in re.split(r"[,\s]+", job.resources.slurm_account) if a
+            ]
             for account in accounts:
                 # here, we check whether the given or guessed account is valid
                 # if not, a WorkflowError is raised


### PR DESCRIPTION
We need to perform the account testing with `sacctmgr`, first, then with `sshare`. `sshare` might not provide all accounts, as SLURM in a multicluster environment is only queried on one cluster. This is an observation from my cluster, where `sshare` did only show accounts for cluster _A_, whereas `sacctmgr` displayed for clusters `A` and `B`.

The reason is, that `sshare` queries the `slurmctld` of a given cluster, whereas `sacctmgr` queries the overlooking SLURM database of all clusters in a multi cluster environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept multiple SLURM accounts (comma/space-separated) and handle each as a distinct account entry; when multiple provided, the first is used for submission.
  * Safer quoting for account and partition values to prevent shell injection.

* **Bug Fixes**
  * Prefer sacctmgr for account validation in multicluster setups, falling back to sshare when needed.
  * Deduplicate reported accounts and provide clearer combined error reports when validation fails.

* **Documentation**
  * Clarified messages and comments about multicluster validation and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->