### PR TITLE
feat: new flag for SLURM qos

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -627,6 +627,10 @@ With `--slurm-efficiency-report` you can generate a table of all efficiency data
 The plugin allows specifying a flag `--slurm-reservation=<name>` to use a particular reservation.
 It does not validate the spelling nor eligibility to this reservation.
 
+### Using SLURM QoS
+
+To use SLURM's quality of service flags (`--qos` to `sbatch`) the plugin allows specifying `--slurm-qos=<qos-string>`, too. Both, the reservation and the qos may be particularly useful in a course setting.
+
 ### Frequently Asked Questions
 
 #### Should I run Snakemake on the Login Node of my Cluster?

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -140,6 +140,14 @@ class ExecutorSettings(ExecutorSettingsBase):
             "This flag has no effect, if not set.",
         },
     )
+    qos: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "If set, the given QoS will be used for job submission.",
+            "env_var": False,
+            "required": False,
+        },
+    )
     reservation: Optional[str] = field(
         default=None,
         metadata={
@@ -309,6 +317,9 @@ class Executor(RemoteExecutor):
         if self.workflow.executor_settings.requeue:
             call += " --requeue"
 
+        if self.job.workflow.executor_settings.qos:
+            call += f" --qos={self.job.workflow.executor_settings.qos}"
+            
         if self.workflow.executor_settings.reservation:
             call += f" --reservation={self.workflow.executor_settings.reservation}"
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -317,8 +317,8 @@ class Executor(RemoteExecutor):
         if self.workflow.executor_settings.requeue:
             call += " --requeue"
 
-        if self.job.workflow.executor_settings.qos:
-            call += f" --qos={self.job.workflow.executor_settings.qos}"
+        if self.workflow.executor_settings.qos:
+            call += f" --qos={self.workflow.executor_settings.qos}"
 
         if self.workflow.executor_settings.reservation:
             call += f" --reservation={self.workflow.executor_settings.reservation}"

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -319,7 +319,7 @@ class Executor(RemoteExecutor):
 
         if self.job.workflow.executor_settings.qos:
             call += f" --qos={self.job.workflow.executor_settings.qos}"
-            
+
         if self.workflow.executor_settings.reservation:
             call += f" --reservation={self.workflow.executor_settings.reservation}"
 


### PR DESCRIPTION
a new flag `--slurm-qos` has been added to conform with reservations requiring a particular qos upon job submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SLURM QoS support for job submissions. Users can specify a QoS via a new --slurm-qos=<qos> CLI option or corresponding executor setting; no change occurs when unset.

* **Documentation**
  * Added “Using SLURM QoS” under SLURM reservations, explaining how to configure QoS alongside reservations and the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->