### PR TITLE
feat: preventing overwrites

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -486,8 +486,10 @@ rule myrule:
     input: ...
     output: ...
     resources:
-        slurm_extra="--qos=long --mail-type=ALL --mail-user=<your email>"
+        slurm_extra="--mail-type=ALL --mail-user=<your email>"
 ```
+
+.. note:: We prevent you from overwriting all flags, which are used or configurable internally. This prevents conflicts and breaking job submission.
 
 Again, rather use a [profile](https://snakemake.readthedocs.io/en/latest/executing/cli.html#profiles) to specify such resources.
 

--- a/snakemake_executor_plugin_slurm/validation.py
+++ b/snakemake_executor_plugin_slurm/validation.py
@@ -1,0 +1,75 @@
+"""
+SLURM parameter validation functions for the Snakemake executor plugin.
+"""
+
+import re
+from snakemake_interface_common.exceptions import WorkflowError
+
+
+def get_forbidden_slurm_options():
+    """
+    Return a dictionary of forbidden SLURM options that the executor plugin manages.
+    
+    Returns:
+        dict: Mapping of regex patterns to human-readable option names
+    """
+    return {
+        # Job identification and output
+        r"--job-name[=\s]|-J\s?": "job name",
+        r"--output[=\s]|-o\s": "output file",
+        r"--error[=\s]|-e\s": "error file",
+        r"--parsable": "parsable output",
+        r"--export[=\s]": "environment export",
+        r"--comment[=\s]": "job comment",
+        r"--workdir[=\s]|-D\s": "working directory",
+        
+        # Account and partition
+        r"--account[=\s]|-A\s": "account",
+        r"--partition[=\s]|-p\s": "partition",
+        
+        # Memory options
+        r"--mem[=\s]": "memory",
+        r"--mem-per-cpu[=\s]": "memory per CPU",
+        
+        # CPU and task options
+        r"--ntasks[=\s]|-n\s": "number of tasks",
+        r"--ntasks-per-gpu[=\s]": "tasks per GPU",
+        r"--cpus-per-task[=\s]|-c\s": "CPUs per task",
+        r"--cpus-per-gpu[=\s]": "CPUs per GPU",
+        
+        # Time and resource constraints
+        r"--time[=\s]|-t\s": "runtime/time limit",
+        r"--constraint[=\s]|-C\s": "node constraints", 
+        r"--qos[=\s]": "quality of service",
+        r"--nodes[=\s]|-N\s": "number of nodes",
+        r"--clusters[=\s]": "cluster specification",
+        
+        # GPU options
+        r"--gres[=\s]": "generic resources (GRES)",
+        r"--gpus[=\s]": "GPU allocation",
+    }
+
+
+def validate_slurm_extra(job):
+    """
+    Validate that slurm_extra doesn't contain options managed by the executor plugin.
+    
+    Args:
+        job: Snakemake job object with resources attribute
+        
+    Raises:
+        WorkflowError: If forbidden SLURM options are found in slurm_extra
+    """
+    if not hasattr(job.resources, 'slurm_extra') or not job.resources.slurm_extra:
+        return
+        
+    forbidden_options = get_forbidden_slurm_options()
+    
+    for pattern, option_name in forbidden_options.items():
+        if re.search(pattern, job.resources.slurm_extra):
+            raise WorkflowError(
+                f"The --{option_name.replace(' ', '-')} option is not allowed in the 'slurm_extra' parameter. "
+                f"The {option_name} is set by the snakemake executor plugin and must not be overwritten. "
+                f"Please use the appropriate snakemake resource specification instead. "
+                f"Consult the documentation for proper resource configuration."
+            )


### PR DESCRIPTION
From this PR onwards, overwriting flags already used internally with the `slurm_extra` parameter. The plugin is feature rich and gets improved continuously. Overwriting internally used flags (via CLI or resources) already caused a number of issues. Now, we should have a reasonable error message, instead.