### PR TITLE
fix: #348 no attempts to jobstep executor

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -343,6 +343,11 @@ class Executor(RemoteExecutor):
 
         exec_job = self.format_job_exec(job)
 
+        # Prevent forwarding Snakemake retry attempts into the remote
+        # jobstep. Convert any "--attempt <n>" or "--attempt=<n>" to
+        # a single attempt in the remote context.
+        exec_job = re.sub(r"--attempt(?:[=\s]+)\d+", "--attempt 1", exec_job)
+
         # and finally the job to execute with all the snakemake parameters
         call += f' --wrap="{exec_job}"'
 


### PR DESCRIPTION
Addresses issue #384, possibly #284, too.

 It submits Snakemake itself and ensures invoking the jobstep plugin.

There is an issue with that: Snakemake' `--retries` flag will be forwarded to the remote executor, the jobstep executor. The user may try new attempts with different resources, but will never get them in the new job context: The resource allocation is fixed per active SLURM job and cannot be extended. Any retry attempt has to be triggered from the main Snakemake process.

Hence, we need a regex to always convert `--attempt <some integer>` into `--attempt 1` in the exec_job string.

@johanneskoester as we agreed not to temper the `exec_job` string, I assigned you as a reviewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry attempt handling in remote job submissions. Retry attempts are now properly normalized to a single attempt in the remote execution context, ensuring consistent job behavior across Slurm submissions and preventing unintended retry propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->