### PR TITLE
docs: Replace incorrect Markdown with a blockquote

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -689,9 +689,7 @@ The corresponding command line flag is not needed anymore.
 
 Using the [file system storage plugin](https://github.com/snakemake/snakemake-storage-plugin-fs) will automatically stage-in and -out in- and output files.
 
-
-==This is ongoing development.
-Eventually, you will be able to annotate different file access patterns.==
+> This is ongoing development. Eventually, you will be able to annotate different file access patterns.
 
 ### Log Files - Getting Information on Failures
 


### PR DESCRIPTION
In https://snakemake.github.io/snakemake-plugin-catalog/plugins/executor/slurm.html#setting-up-a-global-profile, there is a sentence that isn't formatted correctly:

```
==This is ongoing development. Eventually, you will be able to annotate different file access patterns.==
```

This PR changes that into a blockquote, which looks better:

> This is ongoing development. Eventually, you will be able to annotate different file access patterns.==

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting of development status notes in the documentation for improved visual presentation and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->