### PR TITLE
fix: validator check for integers was broken.

### DIFF
--- a/snakemake_executor_plugin_slurm/validation.py
+++ b/snakemake_executor_plugin_slurm/validation.py
@@ -132,7 +132,7 @@ def validate_executor_settings(settings, logger=None):
     if settings.init_seconds_before_status_checks is not None:
         if (
             not isinstance(settings.init_seconds_before_status_checks, int)
-            or settings.init_seconds_before_status_checks < 0
+            or settings.init_seconds_before_status_checks < 1
         ):
             raise WorkflowError(
                 "init-seconds-before-status-checks must be a positive integer."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation updated for the initialization delay before status checks: integer values of 1 and above are now accepted, whereas previously only zero or negative values were allowed. Type checking remains enforced so only integers are permitted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->