### PR TITLE
fix: updated gpu model string - may contain a period, now

### DIFF
--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -176,9 +176,11 @@ def set_gres_string(job: JobExecutorInterface) -> str:
     """
     # generic resources (GRES) arguments can be of type
     # "string:int" or "string:string:int"
-    gres_re = re.compile(r"^[a-zA-Z0-9_]+(:[a-zA-Z0-9_]+)?:\d+$")
+    gres_re = re.compile(r"^[a-zA-Z0-9_]+(:[a-zA-Z0-9_\.]+)?:\d+$")
     # gpu model arguments can be of type "string"
-    gpu_model_re = re.compile(r"^[a-zA-Z0-9_]+$")
+    # The model string may contain a dot for variants, see
+    # https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/387
+    gpu_model_re = re.compile(r"^[a-zA-Z0-9_\.]+$")
     # any arguments should not start and end with ticks or
     # quotation marks:
     string_check = re.compile(r"^[^'\"].*[^'\"]$")


### PR DESCRIPTION
This is a tiny update to the GPU model string, see https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to support GPU model names and GRES resource identifiers containing dots (e.g., "gpu:tesla.x"). This resolves issues where certain GPU configurations were previously rejected during validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->