### PR TITLE
fix: jobstep plugin with new functionality required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["snakemake", "plugin", "executor", "cluster", "slurm"]
 python = "^3.11"
 snakemake-interface-common = "^1.21.0"
 snakemake-interface-executor-plugins = "^9.3.9"
-snakemake-executor-plugin-slurm-jobstep = "^0.3.0"
+snakemake-executor-plugin-slurm-jobstep = "^0.4.0"
 pandas = "^2.2.3"
 numpy = ">=1.26.4, <3"
 throttler = "^1.2.2"


### PR DESCRIPTION
bumping jobstep plugin version requirement to 0.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SLURM job step executor plugin dependency to the latest compatible version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->