### PR TITLE
fix: status hang when no active jobs

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -666,11 +666,6 @@ class Executor(RemoteExecutor):
         # decide which status command to use
         status_command_name = self.get_status_command()
         min_job_age = get_min_job_age()
-        initial_interval = getattr(
-            self.workflow.executor_settings,
-            "init_seconds_before_status_checks",
-            40,
-        )
         dynamic_check_threshold = 3 * initial_interval
         if status_command_name == "squeue":
             if (
@@ -800,7 +795,7 @@ We leave it to SLURM to resume your job(s)"""
                     max_sleep_time,
                 )
             else:
-                self.next_seconds_between_status_checks = 40
+                self.next_seconds_between_status_checks = initial_interval
 
     def cancel_jobs(self, active_jobs: List[SubmittedJobInfo]):
         # Cancel all active jobs.


### PR DESCRIPTION
When running from a SLURM job (I know this is discouraged...) somehow `check_active_jobs()` was called before there were any active jobs, which made it hang (it never hit a yield or return statement). This fixed it for me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized job status checking to skip unnecessary queries when no jobs are active
  * Made status check intervals configurable for more flexible resource management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->