### PR TITLE
fix: quoting for SLURM partition

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -968,6 +968,7 @@ We leave it to SLURM to resume your job(s)"""
         if partition:
             # we have to quote the partition, because it might
             # contain build-in shell commands
+            # string conversion needed for partition if partition is an integer
             return f" -p {shlex.quote(str(partition))}"
         else:
             return ""


### PR DESCRIPTION
Fixes TypeError when partition is an int. (TypeError: expected string or bytes-like object, got 'int' from shlex.quote())

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safely handle SLURM partition inputs by converting non-string values to strings before quoting, preventing errors when users provide numeric or other non-string partition values and improving robustness of partition handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->