### PR TITLE
fix: quoting piped substring with shlex

### DIFF
--- a/snakemake_executor_plugin_slurm/job_status_query.py
+++ b/snakemake_executor_plugin_slurm/job_status_query.py
@@ -143,8 +143,11 @@ def query_job_status_squeue(runid) -> list:
         Dictionary mapping job ID to JobStatus object
     """
     # Build squeue command
+    # Note: The format string contains a pipe '|' which must be quoted to
+    # prevent shell interpretation when passing to subprocess with shell=True
+    format_arg = shlex.quote("%i|%T")
     query_command = f"""squeue
-                       --format=%i|%T
+                       --format={format_arg}
                        --states=all
                        --noheader
                        --name {runid}"""


### PR DESCRIPTION
The substring `"%i|%T"` is now quoted with `shlex.quote`. This ensures that it will work on any standard shell and should fix issue #395.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced stability of job status queries by properly handling shell command arguments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->