### PR TITLE
fix: decreasing job query verbosity

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -716,16 +716,16 @@ class Executor(RemoteExecutor):
                     active_jobs_seen_by_sacct
                     - active_jobs_ids_with_current_sacct_status
                 )
+                active_jobs_seen_by_sacct = (
+                    active_jobs_seen_by_sacct
+                    | active_jobs_ids_with_current_sacct_status
+                )
                 # Only log detailed debug info on final attempt or when complete.
                 # This avoids log flooding in verbose mode.
                 if not missing_sacct_status or i + 1 == status_attempts:
                     self.logger.debug(
                         f"active_jobs_ids_with_current_sacct_status are: "
                         f"{active_jobs_ids_with_current_sacct_status}"
-                    )
-                    active_jobs_seen_by_sacct = (
-                        active_jobs_seen_by_sacct
-                        | active_jobs_ids_with_current_sacct_status
                     )
                     self.logger.debug(
                         "active_jobs_seen_by_sacct are: "


### PR DESCRIPTION
This PR addresses issue #398 to some extent in that it decreases the job query output. This is particularly important when starting with the `--verbose` flag of Snakemake or - in the case of this plugin - the workflow has extended pending times when job status queries need to be performed repeatedly. By not giving an output upon every query, the corresponding log file does not grow too quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive debug logging during job status checks by consolidating and conditionally emitting status details only on final retries or when complete information is available, preventing redundant output during intermediate attempts.
  * Added explicit " (final attempt)" markers to log lines when a status query yields no data on the last retry, improving visibility of final-check outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->