### PR TITLE
fix: tbdstring handling

### DIFF
--- a/snakemake_executor_plugin_slurm/partitions.py
+++ b/snakemake_executor_plugin_slurm/partitions.py
@@ -292,11 +292,11 @@ class Partition:
 
         for resource_key, limit in numerical_resources.items():
             job_requirement = job.resources.get(resource_key, 0)
-            # return 0 if dealing with a tbdstring (resource not specified)
+            # Skip TBD (not specified) resources entirely
             if isinstance(job_requirement, tbdstring.TBDString):
-                return 0
+                job_requirement = 0
             # Convert to numeric value if it's a string
-            if isinstance(job_requirement, str):
+            elif isinstance(job_requirement, str):
                 try:
                     job_requirement = float(job_requirement)
                 except ValueError:

--- a/snakemake_executor_plugin_slurm/partitions.py
+++ b/snakemake_executor_plugin_slurm/partitions.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 import yaml
 from pathlib import Path
 from math import inf, isinf
+from snakemake.common import tbdstring
 from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_executor_plugins.jobs import (
     JobExecutorInterface,
@@ -291,6 +292,9 @@ class Partition:
 
         for resource_key, limit in numerical_resources.items():
             job_requirement = job.resources.get(resource_key, 0)
+            # return 0 if dealing with a tbdstring (resource not specified)
+            if isinstance(job_requirement, tbdstring.TBDString):
+                return 0
             # Convert to numeric value if it's a string
             if isinstance(job_requirement, str):
                 try:


### PR DESCRIPTION
During testing, it occurred that unset resource values (which yield a tbd string) will cause a workflow to break, if used in conjunction with the storage-fs plugin.

This PR is 

1. a mitigation attempt
2. should raise concern, that such an error has not been reported before (are people not using the different plugins in combination?)
3. should cause implementation of tests together with the fs storage plugin (not part of this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unspecified or placeholder job resource values are now treated as zero, avoiding misestimation of resource needs.
  * Prevented duplicate interpretation of resource specifications, improving partition selection and scheduling reliability.
  * Non-numeric resource values now safely fall back to zero to avoid scheduling errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->