### PR TITLE
fix: Add direct dependency on PyYAML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ snakemake-executor-plugin-slurm-jobstep = "^0.4.0"
 pandas = "^2.2.3"
 numpy = ">=1.26.4, <3"
 throttler = "^1.2.2"
+pyyaml = "^6.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"


### PR DESCRIPTION
This plugin imports `yaml` directly:

https://github.com/snakemake/snakemake-executor-plugin-slurm/blob/31aeb667675c80cc7764fa891f727e2bf48c87b3/snakemake_executor_plugin_slurm/cli.py#L24

https://github.com/snakemake/snakemake-executor-plugin-slurm/blob/31aeb667675c80cc7764fa891f727e2bf48c87b3/snakemake_executor_plugin_slurm/partitions.py#L3

Therefore, it should have a direct dependency on PyYAML rather than relying on snakemake being installed and pulling it in indirectly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pyyaml as a new runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->