### PR TITLE
fix: silent crashes on sbatch whend pwd!=workdir

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -355,6 +355,18 @@ common_settings = CommonSettings(
     auto_deploy_default_storage_provider=False,
 )
 
+def _select_logdir(workflow) : 
+    """Selects where slurm_logdir should be created"""
+    logdir = workflow.executor_settings.logdir
+    # logdir is defined as absolute, keep "as is"
+    if logdir and str(logdir).startswith("/"):  
+        return Path(logdir)
+    # logdir is relative, we ensure it stays relative to the wokflow's workdir
+    elif logdir : 
+        return Path(workflow.workdir_init) / workflow.executor_settings.logdir
+    # logdir is unset
+    else : 
+        return Path(".snakemake/slurm_logs").resolve()
 
 # Required:
 # Implementation of your executor
@@ -398,11 +410,7 @@ class Executor(RemoteExecutor):
         self._status_query_min_seconds = None
         self._status_query_max_seconds = 0.0
         self._status_query_cycle_rows = []
-        self.slurm_logdir = (
-            Path(self.workflow.executor_settings.logdir)
-            if self.workflow.executor_settings.logdir
-            else Path(".snakemake/slurm_logs").resolve()
-        )
+        self.slurm_logdir = _select_logdir(self.workflow)
         # Check the environment variable "SNAKEMAKE_SLURM_PARTITIONS",
         # if set, read the partitions from the given file. Let the CLI
         # option override this behavior.


### PR DESCRIPTION
proposed fix for https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/419: when the config is pointing to an absolute path and different from the workdir, the slurm logs aren't written to the configured directory.