### PR TITLE
fix: handle integer slurm_account values from YAML parsing

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -1293,7 +1293,7 @@ class Executor(RemoteExecutor):
         # slurmdbd/accounting hiccups where job states are briefly incomplete.
         for i in range(status_attempts):
             async with self.status_rate_limiter:
-                (status_of_jobs, sacct_query_duration) = await query_job_status(
+                status_of_jobs, sacct_query_duration = await query_job_status(
                     status_command, self.logger
                 )
                 if status_of_jobs is None and sacct_query_duration is None:
@@ -1589,8 +1589,10 @@ We leave it to SLURM to resume your job(s)"""
         if job.resources.get("slurm_account"):
             # split the account upon ',' and whitespace, to allow
             # multiple accounts being given
+            # Note: YAML parsing may convert numeric strings (e.g. "123456") to int.
+            # Ensure we always work with strings for re.split and shlex.quote.
             accounts = [
-                a for a in re.split(r"[,\s]+", job.resources.slurm_account) if a
+                a for a in re.split(r"[,\s]+", str(job.resources.slurm_account)) if a
             ]
             for account in accounts:
                 # here, we check whether the given or guessed account is valid

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,81 @@
+"""Unit tests for get_account_arg() method."""
+
+from unittest.mock import MagicMock, patch
+
+from snakemake_executor_plugin_slurm import Executor
+
+
+class _Resources(dict):
+    """Dict-like resources with attribute access for known keys only."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+
+def _make_mock_job(
+    rule_name="myrule", name=None, wildcards=None, jobid=1, is_group=False, **resources
+):
+    """Return a minimal mock job compatible with get_account_arg."""
+    mock_resources = _Resources(resources)
+
+    mock_rule = MagicMock()
+    mock_rule.name = rule_name
+
+    job = MagicMock()
+    job.resources = mock_resources
+    job.rule = mock_rule
+    job.name = name if name is not None else rule_name
+    job.wildcards = wildcards if wildcards is not None else {}
+    job.is_group.return_value = is_group
+    job.threads = resources.get("threads", 1)
+    job.jobid = jobid
+    return job
+
+
+class TestGetAccountArg:
+    """Tests for get_account_arg() method handling string and integer accounts."""
+
+    def _make_executor_stub(self):
+        """Return a minimal Executor stub."""
+        executor = Executor.__new__(Executor)
+        executor.logger = MagicMock()
+        executor._fallback_account_arg = None
+        return executor
+
+    # Patches prevent actual SLURM command execution (sacct/sacctmgr).
+    # - get_account() would call 'sacct' to guess account from recent jobs.
+    # - test_account() would call 'sacctmgr' or 'sshare' to validate account.
+    # Mocks allow testing without a live SLURM cluster.
+    @patch("snakemake_executor_plugin_slurm.get_account")
+    @patch("snakemake_executor_plugin_slurm.test_account")
+    def test_string_account(self, mock_test_account, mock_get_account, tmp_path):
+        """String account values work correctly."""
+        executor = self._make_executor_stub()
+        job = _make_mock_job(slurm_account="123456789")
+        result = next(executor.get_account_arg(job))
+        assert result == " -A 123456789"
+        mock_test_account.assert_called_with("123456789", executor.logger)
+
+    @patch("snakemake_executor_plugin_slurm.get_account")
+    @patch("snakemake_executor_plugin_slurm.test_account")
+    def test_integer_account(self, mock_test_account, mock_get_account, tmp_path):
+        """Integer account values (from YAML parsing) work correctly."""
+        executor = self._make_executor_stub()
+        job = _make_mock_job(slurm_account=123456789)
+        result = next(executor.get_account_arg(job))
+        assert result == " -A 123456789"
+        mock_test_account.assert_called_with("123456789", executor.logger)
+
+    @patch("snakemake_executor_plugin_slurm.get_account")
+    @patch("snakemake_executor_plugin_slurm.test_account")
+    def test_multiple_accounts_string(
+        self, mock_test_account, mock_get_account, tmp_path
+    ):
+        """Multiple string accounts work correctly."""
+        executor = self._make_executor_stub()
+        job = _make_mock_job(slurm_account="acc1,acc2 acc3")
+        results = list(executor.get_account_arg(job))
+        assert results == [" -A acc1", " -A acc2", " -A acc3"]


### PR DESCRIPTION
## Summary

Snakemake's YAML parser automatically converts numeric-looking strings (e.g., `"123456789"`) to integers when populating `job.resources`. This caused `account.lower()` in `test_account()` to fail since `int` has no `lower()` method.

## Changes

Convert `slurm_account` values to strings before use in `re.split()` to handle both string and integer values.

## Tests

Added 3 new unit tests covering:
- String account values
- Integer account values (from YAML parsing)
- Multiple string accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize SLURM account inputs (including numeric values) to strings, split multiple accounts, and ensure submission arguments are consistently formatted and quoted.

* **Tests**
  * Added unit tests validating single, numeric, and multi-account scenarios to ensure correct account argument generation and invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->