### PR TITLE
fix: code refactoring

### DIFF
--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -341,8 +341,8 @@ def set_gres_string(job: JobExecutorInterface) -> str:
     Function to set the gres string for the SLURM job
     based on the resources requested in the job.
     """
-    # generic resources (GRES) arguments can be of type
-    # "string", "string:int" or "string:string:int" with optional postfix 'T' or 'G' or 'M'
+    # generic resources (GRES) arguments can be of type "string",
+    # "string:int" or "string:string:int" with optional postfix 'T' or 'G' or 'M'
     gres_re = re.compile(r"^[a-zA-Z0-9_]+(:[a-zA-Z0-9_\.]+)?(:\d+[TGM]?)?$")
 
     # gpu model arguments can be of type "string"

--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -366,17 +366,17 @@ def set_gres_string(job: JobExecutorInterface) -> str:
                 raise WorkflowError(
                     "GRES format should not be a nested string (start "
                     "and end with ticks or quotation marks). "
-                    "Expected format: "
+                    "Expected format: '<name>', "
                     "'<name>:<number>' or '<name>:<type>:<number>' with an optional "
                     "'T' 'M' or 'G' postfix "
-                    "(e.g., 'gpu:1' or 'gpu:tesla:2')"
+                    "(e.g., 'gpu', 'gpu:2' or 'gpu:tesla:1')"
                 )
             else:
                 raise WorkflowError(
                     f"Invalid GRES format: {job.resources.gres}. Expected format: "
                     "'<name>', '<name>:<number>' or '<name>:<type>:<number>' "
                     "with an optional 'T' 'M' or 'G' postfix "
-                    "(e.g., 'gpu:1' or 'gpu:tesla:2') "
+                    "(e.g., 'gpu', 'gpu:1' or 'gpu:tesla:2') "
                 )
         gres += f" --gres={job.resources.gres}"
 

--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -342,35 +342,22 @@ def set_gres_string(job: JobExecutorInterface) -> str:
     based on the resources requested in the job.
     """
     # generic resources (GRES) arguments can be of type
-    # "string:int" or "string:string:int" with optional postfix 'T' or 'G' or 'M'
-    gres_re = re.compile(r"^[a-zA-Z0-9_]+(:[a-zA-Z0-9_\.]+)?:\d+[TGM]?$")
+    # "string", "string:int" or "string:string:int" with optional postfix 'T' or 'G' or 'M'
+    gres_re = re.compile(r"^[a-zA-Z0-9_]+(:[a-zA-Z0-9_\.]+)?(:\d+[TGM]?)?$")
 
     # gpu model arguments can be of type "string"
     # The model string may contain a dot for variants, see
     # https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/387
     gpu_model_re = re.compile(r"^[a-zA-Z0-9_\.]+$")
+
     # any arguments should not start and end with ticks or
     # quotation marks:
     string_check = re.compile(r"^[^'\"].*[^'\"]$")
+
     # The Snakemake resources can be only be of type "int",
     # hence no further regex is needed.
 
-    gpu_string = None
-    if job.resources.get("gpu"):
-        gpu_string = str(job.resources.get("gpu"))
-
-    gpu_model = None
-    if job.resources.get("gpu_model"):
-        gpu_model = job.resources.get("gpu_model")
-
-    # ensure that gres is not set, if gpu and gpu_model are set
-    if job.resources.get("gres") and gpu_string:
-        raise WorkflowError(
-            "GRES and GPU are set. Please only set one of them.", rule=job.rule
-        )
-    elif not job.resources.get("gres") and not gpu_model and not gpu_string:
-        return ""
-
+    gres = ""
     if job.resources.get("gres"):
         # Validate GRES format (e.g., "gpu:1", "gpu:tesla:2")
         gres = job.resources.gres
@@ -391,9 +378,13 @@ def set_gres_string(job: JobExecutorInterface) -> str:
                     "'T' 'M' or 'G' postfix "
                     "(e.g., 'gpu:1' or 'gpu:tesla:2') "
                 )
-        return f" --gres={job.resources.gres}"
+        gres += f" --gres={job.resources.gres}"
 
-    if gpu_model and gpu_string:
+    # Default to 1 GPU
+    gpu_string = str(job.resources.get("gpu", 1))
+    gpu_model = job.resources.get("gpu_model")
+
+    if gpu_model:
         # validate GPU model format
         if not gpu_model_re.match(gpu_model):
             if not string_check.match(gpu_model):
@@ -407,10 +398,10 @@ def set_gres_string(job: JobExecutorInterface) -> str:
                     f"Invalid GPU model format: {gpu_model}."
                     " Expected format: '<name>' (e.g., 'tesla')"
                 )
-        return f" --gpus={gpu_model}:{gpu_string}"
-    elif gpu_model and not gpu_string:
-        raise WorkflowError("GPU model is set, but no GPU number is given")
-    elif gpu_string:
+        gres += f" --gpus={gpu_model}:{gpu_string}"
+    else:
         # we assume here, that the validator ensures that the 'gpu_string'
         # is an integer
-        return f" --gpus={gpu_string}"
+        gres += f" --gpus={gpu_string}"
+
+    return gres

--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -357,6 +357,7 @@ def set_gres_string(job: JobExecutorInterface) -> str:
     # The Snakemake resources can be only be of type "int",
     # hence no further regex is needed.
 
+    # GRES
     gres = ""
     if job.resources.get("gres"):
         # Validate GRES format (e.g., "gpu:1", "gpu:tesla:2")
@@ -379,28 +380,29 @@ def set_gres_string(job: JobExecutorInterface) -> str:
                 )
         gres += f" --gres={job.resources.gres}"
 
-    # Default to 1 GPU
-    gpu_string = str(job.resources.get("gpu", 1))
-    gpu_model = job.resources.get("gpu_model")
-
-    if gpu_model:
-        # validate GPU model format
-        if not gpu_model_re.match(gpu_model):
-            if not string_check.match(gpu_model):
-                raise WorkflowError(
-                    "GPU model format should not be a nested string (start "
-                    "and end with ticks or quotation marks). "
-                    "Expected format: '<name>' (e.g., 'tesla')"
-                )
-            else:
-                raise WorkflowError(
-                    f"Invalid GPU model format: {gpu_model}."
-                    " Expected format: '<name>' (e.g., 'tesla')"
-                )
-        gres += f" --gpus={gpu_model}:{gpu_string}"
-    else:
-        # we assume here, that the validator ensures that the 'gpu_string'
-        # is an integer
-        gres += f" --gpus={gpu_string}"
+    # GPU
+    gpu_string = job.resources.get("gpu")
+    if gpu_string:
+        gpu_string = str(job.resources.gpu)
+        gpu_model = job.resources.get("gpu_model")
+        if gpu_model:
+            # validate GPU model format
+            if not gpu_model_re.match(gpu_model):
+                if not string_check.match(gpu_model):
+                    raise WorkflowError(
+                        "GPU model format should not be a nested string (start "
+                        "and end with ticks or quotation marks). "
+                        "Expected format: '<name>' (e.g., 'tesla')"
+                    )
+                else:
+                    raise WorkflowError(
+                        f"Invalid GPU model format: {gpu_model}."
+                        " Expected format: '<name>' (e.g., 'tesla')"
+                    )
+            gres += f" --gpus={gpu_model}:{gpu_string}"
+        else:
+            # we assume here, that the validator ensures that the 'gpu_string'
+            # is an integer
+            gres += f" --gpus={gpu_string}"
 
     return gres

--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -360,9 +360,8 @@ def set_gres_string(job: JobExecutorInterface) -> str:
     gres = ""
     if job.resources.get("gres"):
         # Validate GRES format (e.g., "gpu:1", "gpu:tesla:2")
-        gres = job.resources.gres
-        if not gres_re.match(gres):
-            if not string_check.match(gres):
+        if not gres_re.match(job.resources.gres):
+            if not string_check.match(job.resources.gres):
                 raise WorkflowError(
                     "GRES format should not be a nested string (start "
                     "and end with ticks or quotation marks). "
@@ -373,7 +372,7 @@ def set_gres_string(job: JobExecutorInterface) -> str:
                 )
             else:
                 raise WorkflowError(
-                    f"Invalid GRES format: {gres}. Expected format: "
+                    f"Invalid GRES format: {job.resources.gres}. Expected format: "
                     "'<name>:<number>' or '<name>:<type>:<number>' with an optional "
                     "'T' 'M' or 'G' postfix "
                     "(e.g., 'gpu:1' or 'gpu:tesla:2') "

--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -382,27 +382,27 @@ def set_gres_string(job: JobExecutorInterface) -> str:
 
     # GPU
     gpu_string = job.resources.get("gpu")
-    if gpu_string:
-        gpu_string = str(job.resources.gpu)
-        gpu_model = job.resources.get("gpu_model")
-        if gpu_model:
-            # validate GPU model format
-            if not gpu_model_re.match(gpu_model):
-                if not string_check.match(gpu_model):
-                    raise WorkflowError(
-                        "GPU model format should not be a nested string (start "
-                        "and end with ticks or quotation marks). "
-                        "Expected format: '<name>' (e.g., 'tesla')"
-                    )
-                else:
-                    raise WorkflowError(
-                        f"Invalid GPU model format: {gpu_model}."
-                        " Expected format: '<name>' (e.g., 'tesla')"
-                    )
-            gres += f" --gpus={gpu_model}:{gpu_string}"
-        else:
-            # we assume here, that the validator ensures that the 'gpu_string'
-            # is an integer
-            gres += f" --gpus={gpu_string}"
+    gpu_model = job.resources.get("gpu_model")
+    if gpu_model:
+        # validate GPU model format
+        if not gpu_model_re.match(gpu_model):
+            if not string_check.match(gpu_model):
+                raise WorkflowError(
+                    "GPU model format should not be a nested string (start "
+                    "and end with ticks or quotation marks). "
+                    "Expected format: '<name>' (e.g., 'tesla')"
+                )
+            else:
+                raise WorkflowError(
+                    f"Invalid GPU model format: {gpu_model}."
+                    " Expected format: '<name>' (e.g., 'tesla')"
+                )
+        # Default GPU to 1
+        gpu_string = job.resources.get("gpu", "1")
+        gres += f" --gpus={gpu_model}:{gpu_string}"
+    elif gpu_string:
+        # we assume here, that the validator ensures that the 'gpu_string'
+        # is an integer
+        gres += f" --gpus={gpu_string}"
 
     return gres

--- a/snakemake_executor_plugin_slurm/utils.py
+++ b/snakemake_executor_plugin_slurm/utils.py
@@ -374,8 +374,8 @@ def set_gres_string(job: JobExecutorInterface) -> str:
             else:
                 raise WorkflowError(
                     f"Invalid GRES format: {job.resources.gres}. Expected format: "
-                    "'<name>:<number>' or '<name>:<type>:<number>' with an optional "
-                    "'T' 'M' or 'G' postfix "
+                    "'<name>', '<name>:<number>' or '<name>:<type>:<number>' "
+                    "with an optional 'T' 'M' or 'G' postfix "
                     "(e.g., 'gpu:1' or 'gpu:tesla:2') "
                 )
         gres += f" --gres={job.resources.gres}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -265,7 +265,7 @@ class TestGresString:
 
         assert set_gres_string(job) == " --gres=gpu:tesla:2"
 
-    def test_invalid_gres_format(self, mock_job):
+    def test_valid_gres_format_gpu(self, mock_job):
         """Test with invalid GRES format."""
         job = mock_job(gres="gpu")
 
@@ -276,10 +276,10 @@ class TestGresString:
             process_mock.communicate.return_value = ("123", "")
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
-        with pytest.raises(WorkflowError, match="Invalid GRES format"):
-            set_gres_string(job)
 
-    def test_invalid_gres_format_missing_count(self, mock_job):
+        assert set_gres_string(job) == " --gpus=1"
+
+    def test_valid_gres_format_gpu_model(self, mock_job):
         """Test with invalid GRES format (missing count)."""
         job = mock_job(gres="gpu:tesla:")
 
@@ -291,8 +291,7 @@ class TestGresString:
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
 
-        with pytest.raises(WorkflowError, match="Invalid GRES format"):
-            set_gres_string(job)
+        assert set_gres_string(job) == " --gpus=tesla:1"
 
     def test_valid_gpu_number(self, mock_job):
         """Test with valid GPU number."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -277,7 +277,7 @@ class TestGresString:
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
 
-        assert set_gres_string(job) == " --gpus=1"
+        assert set_gres_string(job) == " --gres=gpu"
 
     def test_valid_gres_format_gpu_model(self, mock_job):
         """Test with invalid GRES format (missing count)."""
@@ -291,7 +291,7 @@ class TestGresString:
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
 
-        assert set_gres_string(job) == " --gpus=tesla:1"
+        assert set_gres_string(job) == " --gres=tesla:1"
 
     def test_valid_gpu_number(self, mock_job):
         """Test with valid GPU number."""
@@ -361,11 +361,7 @@ class TestGresString:
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
 
-            # test whether the resource setting raises the correct error
-            with pytest.raises(
-                WorkflowError, match="GPU model is set, but no GPU number is given"
-            ):
-                set_gres_string(job)
+        assert set_gres_string(job) == " --gpus=tesla:1"
 
     def test_tmpspace_gres_10G(self, mock_job):
         """Test with valid GRES format (simple)."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -291,7 +291,7 @@ class TestGresString:
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
 
-        assert set_gres_string(job) == " --gres=tesla:1"
+        assert set_gres_string(job) == " --gres=gpu:tesla"
 
     def test_valid_gpu_number(self, mock_job):
         """Test with valid GPU number."""
@@ -389,11 +389,7 @@ class TestGresString:
             process_mock.returncode = 0
             mock_popen.return_value = process_mock
 
-            # Ensure the error is raised when both GRES and GPU are set
-            with pytest.raises(
-                WorkflowError, match="GRES and GPU are set. Please only set one"
-            ):
-                set_gres_string(job)
+        assert set_gres_string(job) == " --gres=gpu:1 --gpus=2"
 
     def test_nested_string_raise(self, mock_job):
         """Test error case when gres is a nested string."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -281,7 +281,7 @@ class TestGresString:
 
     def test_valid_gres_format_gpu_model(self, mock_job):
         """Test with invalid GRES format (missing count)."""
-        job = mock_job(gres="gpu:tesla:")
+        job = mock_job(gres="gpu:tesla")
 
         # Patch subprocess.Popen to capture the sbatch command
         with patch("subprocess.Popen") as mock_popen:


### PR DESCRIPTION
- allow for both GRES and GPU to be specified (for example, `gpu` with some network specs)
- assume default GPU of 1
- GRES can be just a string since, according to docs, slurm will assume 1:

**--gres=<list>**
    Specifies a comma-delimited list of generic consumable resources requested per node. The format for each entry in the list is "name[[:type]:count]". The name is the type of consumable resource (e.g. gpu). The type is an optional classification for the resource (e.g. a100). The count is the number of those resources with a default value of 1. [...]. Examples of use include "--gres=gpu:2", "--gres=gpu:kepler:2", and "--gres=help". 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened validation for generic resource specs to accept optional subtypes and optional numeric/postfix formats.
  * GPU allocation now consistently appears in job submissions and permits a model identifier without requiring an explicit GPU count (defaults to 1 when omitted).
  * Removed strict mutual-exclusion between generic-resource and GPU settings so combined configurations are allowed.

* **Tests**
  * Updated tests to accept expanded GRES/GPU formats and auto-filled GPU counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->