### PR TITLE
feat: cpu jobs skip gpu partitions

### DIFF
--- a/snakemake_executor_plugin_slurm/partitions.py
+++ b/snakemake_executor_plugin_slurm/partitions.py
@@ -264,7 +264,7 @@ def get_best_partition(
     for p in candidate_partitions:
         score = p.score_job_fit(job)
         logger.debug(f"Partition '{p.name}' score for job {job.name}: {score}")
-        if score is not None and score > 0:
+        if score is not None:
             scored_partitions.append((p, score))
 
     if scored_partitions:
@@ -545,6 +545,9 @@ class Partition:
                 score += cpu_count / self.limits.max_cpus_per_gpu
 
         gpu_count, gpu_model = parse_gpu_requirements(job)
+        if gpu_count == 0 and self.limits.max_gpu > 0:
+            # Disadvantage gpu partitions for cpu only jobs
+            score -= 1
         if gpu_count > 0:
             if self.limits.max_gpu == 0 or gpu_count > self.limits.max_gpu:
                 return None

--- a/tests/test_partition_selection.py
+++ b/tests/test_partition_selection.py
@@ -26,6 +26,7 @@ class TestPartitionSelection:
                 "gpu": {
                     "max_runtime": 720,
                     "max_mem_mb": 256000,
+                    "max_cpus_per_task": 16,
                     "max_gpu": 4,
                     "available_gpu_models": ["a100", "v100"],
                     "supports_mpi": False,


### PR DESCRIPTION
fix: #446

When jobs are submitted with the automatic selection from the config file, the partition with the greatest score for that job is used. This can be a waste of compute resources when gpu partitions are selected for cpu-only jobs.
Here, gpu partitions are given a penalty for cpu-only jobs.

I slightly changed the `basic_partition_config` to take in account the penalty in existent tests. Let me know if it's preferable to create a completely new test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition selection logic to evaluate all scored partitions as valid candidates.
  * Enhanced GPU job scheduling to better assess partition suitability for jobs without GPU requirements.

* **Tests**
  * Updated test configuration with additional resource limit constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->