### PR TITLE
feat: add no-requeue option for #353

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -227,6 +227,7 @@ These are the available options, and the SLURM `sbatch` command line arguments t
 |                      | passed through when explicitly set) |                     |
 | `slurm_account`      | account for resource usage tracking | `--account`         |
 | `slurm_partition`    | partition/queue to submit job(s) to | `--partition`       |
+| `slurm_no_requeue`   | disable the cluster requeue default  | `--no-requeue`      |
 | `slurm_requeue`      | handle `--retries` with SLURM       | `--requeue`                    |
 |                      | functionality                       |                     |
 | `tasks`              | number of concurrent tasks / ranks  | `--ntasks`          |
@@ -322,6 +323,16 @@ snakemake --slurm-requeue ...
 ```
 
 This flag effectively does not consider failed SLURM jobs or preserves job IDs and priorities or allows job priority to be accumulated while pending.
+
+If your cluster enables requeuing by default, you can disable it for submitted jobs
+with `--slurm-no-requeue` instead. This lets Snakemake handle retries, including
+resource increases between attempts:
+
+```console
+snakemake --slurm-no-requeue ...
+```
+
+The `--slurm-requeue` and `--slurm-no-requeue` flags are mutually exclusive.
 
 ##### Node Failure Tracking
 
@@ -864,4 +875,3 @@ Cluster-specific profiles consist of two files:
 To obtain a template for a cluster-specific profile, search at the [Snakemake cluster profiles repository](https://github.com/snakemake/snakemake-cluster-profiles). This repository not only provides configuration templates, but also maintainer contacts and deployment hints.
 
 Your users will install Snakemake by Conda, add this Slurm executor plugin, and source code for their workflows. Alternatively, Snakemake is provided by [Spack](https://packages.spack.io/package.html?name=snakemake) and [Easybuild](https://docs.easybuild.io/version-specific/supported-software/s/snakemake/), which both update regularly.
-

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -250,6 +250,17 @@ class ExecutorSettings(ExecutorSettingsBase):
         },
     )
 
+    no_requeue: bool = field(
+        default=False,
+        metadata={
+            "help": "Prevent SLURM from requeuing jobs. Results in "
+            "`sbatch ... --no-requeue ...` "
+            "This flag has no effect, if not set.",
+            "env_var": False,
+            "required": False,
+        },
+    )
+
     exclude_failed_nodes: Optional[str] = field(
         default=None,
         metadata={

--- a/snakemake_executor_plugin_slurm/submit_string.py
+++ b/snakemake_executor_plugin_slurm/submit_string.py
@@ -142,6 +142,8 @@ def get_submit_command(
 
     if settings and settings.requeue:
         call += " --requeue"
+    elif settings and settings.no_requeue:
+        call += " --no-requeue"
 
     if settings and settings.qos:
         call += f" --qos={safe_quote(settings.qos)}"

--- a/snakemake_executor_plugin_slurm/validation.py
+++ b/snakemake_executor_plugin_slurm/validation.py
@@ -173,6 +173,10 @@ def validate_executor_settings(settings, logger=None):
     Validate ExecutorSettings fields for correctness
     (better user feedback in case of wrong inputs)
     """
+    if settings.requeue and settings.no_requeue:
+        raise WorkflowError(
+            "--slurm-requeue and --slurm-no-requeue are mutually exclusive."
+        )
     # status_command: only allow known values
     if settings.status_command is not None:
         if settings.status_command not in {"sacct", "squeue"}:

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -102,6 +102,7 @@ def _make_executor_stub(array_jobs=None, array_limit=100):
             init_seconds_before_status_checks=40,
             keep_successful_logs=False,
             requeue=False,
+            no_requeue=False,
             qos=None,
             reservation=None,
             pass_command_as_script=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,3 +48,8 @@ def test_jobname_prefix_validation():
 
     with pytest.raises(WorkflowError, match="jobname_prefix"):
         executor.__post_init__(test_mode=True)
+
+
+def test_requeue_options_are_mutually_exclusive():
+    with pytest.raises(WorkflowError, match="mutually exclusive"):
+        ExecutorSettings(requeue=True, no_requeue=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -583,6 +583,23 @@ class TestSLURMResources(TestWorkflows):
             assert "-C " not in sbatch_command
             assert "--qos " not in sbatch_command
 
+    def test_no_requeue_setting(self, mock_job):
+        """Test that no_requeue disables SLURM's cluster default."""
+        job = mock_job()
+        params = {
+            "run_uuid": "test_run",
+            "slurm_logfile": "test_logfile",
+            "comment_str": "test_comment",
+            "account": None,
+            "partition": None,
+            "workdir": ".",
+        }
+        settings = ExecutorSettings(no_requeue=True)
+
+        sbatch_command = get_submit_command(job, params, settings=settings)
+
+        assert " --no-requeue" in sbatch_command
+
     def test_empty_constraint(self, mock_job):
         """Test that an empty constraint is still included in the command."""
         # Create a job with an empty constraint


### PR DESCRIPTION
Addresses my comments in https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/353#issue-3402907753. Simply adds a `--no-requeue` option to prevent SLURM from re-queueing jobs, thereby allowing snakemake to resubmit the jobs with the proper hooks that allow for increased resources on subsequent submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to disable SLURM’s automatic job requeue behavior.
  * Disabled requeueing is applied through generated SLURM submission commands.
  * Prevented simultaneous use of requeue and no-requeue options.

* **Documentation**
  * Documented the new configuration option and its interaction with retry behavior.
  * Added the corresponding SLURM resource mapping and command-line guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->