### PR TITLE
fix: emit job metadata via run_job_pre before Slurm submission

### DIFF
--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -666,7 +666,7 @@ class Executor(RemoteExecutor):
                         "submitted as an array job. "
                         "Submitting it as a regular job instead."
                     )
-                self._job_submission_executor.submit(self.run_job, job)
+                self._submit_job(job)
             else:
                 ready_jobs_by_rule.setdefault(job.rule.name, []).append(job)
 
@@ -703,9 +703,7 @@ class Executor(RemoteExecutor):
                             "but only one pending job is available; submitting "
                             "as a regular job."
                         )
-                        self._job_submission_executor.submit(
-                            self.run_job, same_rule_jobs[0]
-                        )
+                        self._submit_job(same_rule_jobs[0])
                     else:
                         self.logger.debug(
                             "Array job collection incomplete for rule "
@@ -729,9 +727,7 @@ class Executor(RemoteExecutor):
                         f"{rule_name}: {len(same_rule_jobs)} ready, "
                         f"{eligible_jobs} eligible, chunk_size={chunk_size}."
                     )
-                    self._job_submission_executor.submit(
-                        self.run_array_jobs, same_rule_jobs
-                    )
+                    self._submit_array_jobs(same_rule_jobs)
                 continue
             # Non-array mode: submit all ready jobs individually.
             elif len(same_rule_jobs) == 1:
@@ -739,7 +735,7 @@ class Executor(RemoteExecutor):
                     f"Submitting single job for rule {rule_name} as "
                     "array mode is disabled."
                 )
-                self._job_submission_executor.submit(self.run_job, same_rule_jobs[0])
+                self._submit_job(same_rule_jobs[0])
                 continue
             else:
                 self.logger.debug(
@@ -747,7 +743,18 @@ class Executor(RemoteExecutor):
                     f"{rule_name} individually (array mode disabled)."
                 )
                 for job in same_rule_jobs:
-                    self._job_submission_executor.submit(self.run_job, job)
+                    self._submit_job(job)
+
+    def _submit_job(self, job: JobExecutorInterface):
+        """Emit standard job metadata before submitting one Slurm job."""
+        self.run_job_pre(job)
+        self._job_submission_executor.submit(self.run_job, job)
+
+    def _submit_array_jobs(self, jobs: List[JobExecutorInterface]):
+        """Emit metadata for every array member before one array submission."""
+        for job in jobs:
+            self.run_job_pre(job)
+        self._job_submission_executor.submit(self.run_array_jobs, jobs)
 
     def _report_job_submission_threadsafe(self, job_info: SubmittedJobInfo):
         if self._main_event_loop is not None:

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -159,6 +159,16 @@ class TestArrayJobsSettings:
 class TestRunJobsRouting:
     """Tests that run_jobs dispatches to run_job or run_array_jobs correctly."""
 
+    def test_emits_job_info_once_for_each_submitted_job(self):
+        """Every submitted job logs its standard JOB_INFO metadata first."""
+        executor = _make_executor_stub(array_jobs="myrule")
+        jobs = [_make_mock_job(rule_name="myrule", jobid=i) for i in range(3)]
+
+        executor.run_jobs(jobs)
+
+        for job in jobs:
+            job.log_info.assert_called_once()
+
     def test_single_non_array_job_uses_run_job(self):
         """One job with no array setting → run_job is enqueued."""
         executor = _make_executor_stub()
@@ -255,6 +265,8 @@ class TestRunJobsRouting:
         executor.run_jobs(ready_jobs)
 
         assert executor._job_submission_executor.submit.call_count == 0
+        for job in ready_jobs:
+            job.log_info.assert_not_called()
 
     def test_array_rule_submits_at_chunk_size_even_if_more_eligible_in_dag(self):
         """


### PR DESCRIPTION
## Summary
- Call `run_job_pre` before single/array Slurm submissions so loggers get JOB_INFO/meta
- Add unit tests covering that metadata is emitted for submitted jobs and not for deferred ones
## Test plan
- [x] `pytest tests/test_array_jobs.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job submission handling so job information is consistently logged before individual and grouped jobs are submitted.
  * Ensured jobs that are not yet submitted do not produce premature submission logs.
  * Improved consistency across standard, grouped, and array-based job execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->