### PR TITLE
feat: allow to disable the memory array fudge

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -345,6 +345,22 @@ When submitting array jobs, the `--slurm-array-limit` flag defines the
 maximum number of array tasks to be submitted in one job submission.
 If the number of tasks exceeds this limit, multiple array job submissions will be performed. This is useful to avoid hitting cluster limits on the maximum number of array tasks per job. Please obey your cluster limits and set this flag accordingly.
 
+##### Array memory adjustment
+
+By default, the plugin increases an explicit memory request for an array job to
+account for the encoded array-job payload. If a job has no memory constraint,
+the plugin adds a minimal `--mem` request so that this adjustment is not lost.
+
+Some clusters derive memory allocation from other requested resources and do
+not allow an explicit memory option. Disable the adjustment on such clusters:
+
+```console
+snakemake --slurm-array-memory-fudge false ...
+```
+
+The default is `true`, preserving the standard array submission behavior. In a
+Snakemake profile, use `slurm-array-memory-fudge: false` instead.
+
 
 #### MPI-specific Resources
 
@@ -864,4 +880,3 @@ Cluster-specific profiles consist of two files:
 To obtain a template for a cluster-specific profile, search at the [Snakemake cluster profiles repository](https://github.com/snakemake/snakemake-cluster-profiles). This repository not only provides configuration templates, but also maintainer contacts and deployment hints.
 
 Your users will install Snakemake by Conda, add this Slurm executor plugin, and source code for their workflows. Alternatively, Snakemake is provided by [Spack](https://packages.spack.io/package.html?name=snakemake) and [Easybuild](https://docs.easybuild.io/version-specific/supported-software/s/snakemake/), which both update regularly.
-

--- a/docs/further.md
+++ b/docs/further.md
@@ -355,11 +355,11 @@ Some clusters derive memory allocation from other requested resources and do
 not allow an explicit memory option. Disable the adjustment on such clusters:
 
 ```console
-snakemake --slurm-array-memory-fudge false ...
+snakemake --slurm-disable-memory-fudge false ...
 ```
 
 The default is `true`, preserving the standard array submission behavior. In a
-Snakemake profile, use `slurm-array-memory-fudge: false` instead.
+Snakemake profile, use `slurm-disable-memory-fudge: false` instead.
 
 
 #### MPI-specific Resources

--- a/docs/further.md
+++ b/docs/further.md
@@ -355,11 +355,11 @@ Some clusters derive memory allocation from other requested resources and do
 not allow an explicit memory option. Disable the adjustment on such clusters:
 
 ```console
-snakemake --slurm-disable-memory-fudge false ...
+snakemake --slurm-disable-memory-fudge ...
 ```
 
-The default is `true`, preserving the standard array submission behavior. In a
-Snakemake profile, use `slurm-disable-memory-fudge: false` instead.
+The default is `false`, preserving the standard array submission behavior. In a
+Snakemake profile, use `slurm-disable-memory-fudge: true` instead.
 
 
 #### MPI-specific Resources

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -144,6 +144,18 @@ def _get_status_command_help():
     )
 
 
+def _parse_bool(value):
+    """Parse explicit boolean values from CLI and profile configuration."""
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Expected a boolean value, got {value!r}")
+
+
 def _status_lookup_ids(external_jobid: str) -> List[str]:
     """Return candidate IDs for status lookup.
 
@@ -191,6 +203,19 @@ class ExecutorSettings(ExecutorSettingsBase):
             "Please obey your cluster limits and set this flag accordingly.",
             "env_var": False,
             "required": False,
+        },
+    )
+
+    array_memory_fudge: Optional[bool] = field(
+        default=True,
+        metadata={
+            "help": "Increase an explicit SLURM memory request for array jobs "
+            "to account for the encoded job payload. When no memory resource is "
+            "set, the executor adds a minimal --mem request. Disable this on "
+            "clusters whose memory allocation is derived from other resources.",
+            "env_var": False,
+            "required": False,
+            "type": _parse_bool,
         },
     )
 
@@ -896,7 +921,8 @@ class Executor(RemoteExecutor):
                 # add memory fudge factor to the base call,
                 # to account for the extra memory needed by the
                 # jobstep process to hold and parse the array execs payload.
-                call = apply_mem_fudge(call, array_execs_payload)
+                if self.workflow.executor_settings.array_memory_fudge:
+                    call = apply_mem_fudge(call, array_execs_payload)
 
                 use_script_submission = (
                     self.workflow.executor_settings.pass_command_as_script

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -143,6 +143,7 @@ def _get_status_command_help():
         f"Set explicitly to override auto-detection."
     )
 
+
 def _status_lookup_ids(external_jobid: str) -> List[str]:
     """Return candidate IDs for status lookup.
 

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -194,7 +194,7 @@ class ExecutorSettings(ExecutorSettingsBase):
         },
     )
 
-    disable_memory_fudge: Optional[bool] = field(
+    disable_memory_fudge: bool = field(
         default=False,
         metadata={
             "help": "Increase an explicit SLURM memory request for array jobs "

--- a/snakemake_executor_plugin_slurm/__init__.py
+++ b/snakemake_executor_plugin_slurm/__init__.py
@@ -143,19 +143,6 @@ def _get_status_command_help():
         f"Set explicitly to override auto-detection."
     )
 
-
-def _parse_bool(value):
-    """Parse explicit boolean values from CLI and profile configuration."""
-    if isinstance(value, bool):
-        return value
-    normalized = str(value).strip().lower()
-    if normalized in {"1", "true", "yes", "on"}:
-        return True
-    if normalized in {"0", "false", "no", "off"}:
-        return False
-    raise ValueError(f"Expected a boolean value, got {value!r}")
-
-
 def _status_lookup_ids(external_jobid: str) -> List[str]:
     """Return candidate IDs for status lookup.
 
@@ -206,8 +193,8 @@ class ExecutorSettings(ExecutorSettingsBase):
         },
     )
 
-    array_memory_fudge: Optional[bool] = field(
-        default=True,
+    disable_memory_fudge: Optional[bool] = field(
+        default=False,
         metadata={
             "help": "Increase an explicit SLURM memory request for array jobs "
             "to account for the encoded job payload. When no memory resource is "
@@ -215,7 +202,6 @@ class ExecutorSettings(ExecutorSettingsBase):
             "clusters whose memory allocation is derived from other resources.",
             "env_var": False,
             "required": False,
-            "type": _parse_bool,
         },
     )
 
@@ -925,7 +911,7 @@ class Executor(RemoteExecutor):
                 # add memory fudge factor to the base call,
                 # to account for the extra memory needed by the
                 # jobstep process to hold and parse the array execs payload.
-                if self.workflow.executor_settings.array_memory_fudge:
+                if not self.workflow.executor_settings.disable_memory_fudge:
                     call = apply_mem_fudge(call, array_execs_payload)
 
                 use_script_submission = (

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -24,6 +24,7 @@ import pytest
 from snakemake_executor_plugin_slurm import (
     Executor,
     ExecutorSettings,
+    _parse_bool,
     _status_lookup_ids,
 )
 
@@ -98,6 +99,7 @@ def _make_executor_stub(array_jobs=None, array_limit=100):
     executor.workflow = SimpleNamespace(
         executor_settings=SimpleNamespace(
             array_limit=array_limit,
+            array_memory_fudge=True,
             status_attempts=1,
             init_seconds_before_status_checks=40,
             keep_successful_logs=False,
@@ -129,6 +131,19 @@ class TestArrayJobsSettings:
         """array_limit field defaults to 1000."""
         settings = ExecutorSettings()
         assert settings.array_limit == 1000
+
+    def test_array_memory_fudge_defaults_to_true(self):
+        """Existing array memory behavior remains enabled by default."""
+        settings = ExecutorSettings()
+        assert settings.array_memory_fudge is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "no", "off"])
+    def test_array_memory_fudge_parser_accepts_false_values(self, value):
+        assert _parse_bool(value) is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on"])
+    def test_array_memory_fudge_parser_accepts_true_values(self, value):
+        assert _parse_bool(value) is True
 
     def test_array_jobs_none_yields_empty_set_on_executor(self):
         """Executor with array_jobs=None initialises self.array_jobs as empty set."""
@@ -382,6 +397,30 @@ class TestRunArrayJobs:
         assert "1" not in array_execs
         assert "2" in array_execs
         assert "3" in array_execs
+
+    def test_array_memory_fudge_can_be_disabled(
+        self, tmp_path, mock_popen_success
+    ):
+        executor = self._build_executor(tmp_path)
+        executor.workflow.executor_settings.array_memory_fudge = False
+        jobs = self._make_jobs(n=2)
+
+        executor.run_array_jobs(jobs)
+
+        popen_call_str = mock_popen_success.call_args_list[0][0][0]
+        assert "--mem " not in popen_call_str
+        assert "--mem-per-cpu " not in popen_call_str
+
+    def test_array_memory_fudge_remains_enabled_by_default(
+        self, tmp_path, mock_popen_success
+    ):
+        executor = self._build_executor(tmp_path)
+        jobs = self._make_jobs(n=2)
+
+        executor.run_array_jobs(jobs)
+
+        popen_call_str = mock_popen_success.call_args_list[0][0][0]
+        assert "--mem 1" in popen_call_str
 
     def test_array_execs_omits_first_task_of_each_chunk(self, tmp_path):
         """For each chunk, first task uses base exec command and is absent from map."""

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -24,7 +24,6 @@ import pytest
 from snakemake_executor_plugin_slurm import (
     Executor,
     ExecutorSettings,
-    _parse_bool,
     _status_lookup_ids,
 )
 
@@ -132,18 +131,10 @@ class TestArrayJobsSettings:
         settings = ExecutorSettings()
         assert settings.array_limit == 1000
 
-    def test_array_memory_fudge_defaults_to_true(self):
+    def test_disable_memory_fudge_defaults_to_false(self):
         """Existing array memory behavior remains enabled by default."""
         settings = ExecutorSettings()
-        assert settings.array_memory_fudge is True
-
-    @pytest.mark.parametrize("value", ["false", "False", "0", "no", "off"])
-    def test_array_memory_fudge_parser_accepts_false_values(self, value):
-        assert _parse_bool(value) is False
-
-    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on"])
-    def test_array_memory_fudge_parser_accepts_true_values(self, value):
-        assert _parse_bool(value) is True
+        assert settings.disable_memory_fudge is False
 
     def test_array_jobs_none_yields_empty_set_on_executor(self):
         """Executor with array_jobs=None initialises self.array_jobs as empty set."""

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -100,6 +100,7 @@ def _make_executor_stub(array_jobs=None, array_limit=100):
             array_limit=array_limit,
             status_attempts=1,
             init_seconds_before_status_checks=40,
+            disable_memory_fudge=False,
             keep_successful_logs=False,
             requeue=False,
             no_requeue=False,

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -400,9 +400,7 @@ class TestRunArrayJobs:
         assert "2" in array_execs
         assert "3" in array_execs
 
-    def test_memory_fudge_can_be_disabled(
-        self, tmp_path, mock_popen_success
-    ):
+    def test_memory_fudge_can_be_disabled(self, tmp_path, mock_popen_success):
         executor = self._build_executor(tmp_path)
         executor.workflow.executor_settings.disable_memory_fudge = True
         jobs = self._make_jobs(n=2)

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -98,7 +98,6 @@ def _make_executor_stub(array_jobs=None, array_limit=100):
     executor.workflow = SimpleNamespace(
         executor_settings=SimpleNamespace(
             array_limit=array_limit,
-            array_memory_fudge=True,
             status_attempts=1,
             init_seconds_before_status_checks=40,
             keep_successful_logs=False,
@@ -405,7 +404,7 @@ class TestRunArrayJobs:
         self, tmp_path, mock_popen_success
     ):
         executor = self._build_executor(tmp_path)
-        executor.workflow.executor_settings.array_memory_fudge = False
+        executor.workflow.executor_settings.disable_memory_fudge = True
         jobs = self._make_jobs(n=2)
 
         executor.run_array_jobs(jobs)
@@ -414,7 +413,7 @@ class TestRunArrayJobs:
         assert "--mem " not in popen_call_str
         assert "--mem-per-cpu " not in popen_call_str
 
-    def test_array_memory_fudge_remains_enabled_by_default(
+    def test_memory_fudge_remains_enabled_by_default(
         self, tmp_path, mock_popen_success
     ):
         executor = self._build_executor(tmp_path)

--- a/tests/test_array_jobs.py
+++ b/tests/test_array_jobs.py
@@ -400,7 +400,7 @@ class TestRunArrayJobs:
         assert "2" in array_execs
         assert "3" in array_execs
 
-    def test_array_memory_fudge_can_be_disabled(
+    def test_memory_fudge_can_be_disabled(
         self, tmp_path, mock_popen_success
     ):
         executor = self._build_executor(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ are to be tested separately from the full
 executor functionality.
 """
 
+from argparse import ArgumentParser
 from unittest.mock import MagicMock, patch
 import uuid
 
@@ -13,6 +14,23 @@ import pytest
 
 from snakemake_executor_plugin_slurm import Executor, ExecutorSettings
 from snakemake_interface_common.exceptions import WorkflowError
+from snakemake_interface_common.plugin_registry.plugin import PluginBase
+
+
+class _SlurmSettingsPlugin(PluginBase[ExecutorSettings]):
+    """Minimal plugin wrapper for exercising the settings resolution path."""
+
+    @property
+    def name(self) -> str:
+        return "slurm"
+
+    @property
+    def cli_prefix(self) -> str:
+        return "slurm"
+
+    @property
+    def settings_cls(self):
+        return ExecutorSettings
 
 
 def _make_executor(jobname_prefix: str):
@@ -48,3 +66,15 @@ def test_jobname_prefix_validation():
 
     with pytest.raises(WorkflowError, match="jobname_prefix"):
         executor.__post_init__(test_mode=True)
+
+
+def test_array_memory_fudge_false_resolves_from_cli():
+    """The executor setting must not retain the truthy string ``"false"``."""
+    plugin = _SlurmSettingsPlugin()
+    parser = ArgumentParser()
+    plugin.register_cli_args(parser, "executor")
+
+    args = parser.parse_args(["--slurm-array-memory-fudge", "false"])
+    settings = plugin.get_settings(args)
+
+    assert settings.array_memory_fudge is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,8 @@ def test_disable_memory_fudge_false_resolves_from_cli():
     settings = plugin.get_settings(args)
 
     assert settings.array_memory_fudge is True
+
+
 def test_requeue_options_are_mutually_exclusive():
     with pytest.raises(WorkflowError, match="mutually exclusive"):
         ExecutorSettings(requeue=True, no_requeue=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,13 +68,13 @@ def test_jobname_prefix_validation():
         executor.__post_init__(test_mode=True)
 
 
-def test_array_memory_fudge_false_resolves_from_cli():
+def test_disable_memory_fudge_false_resolves_from_cli():
     """The executor setting must not retain the truthy string ``"false"``."""
     plugin = _SlurmSettingsPlugin()
     parser = ArgumentParser()
     plugin.register_cli_args(parser, "executor")
 
-    args = parser.parse_args(["--slurm-array-memory-fudge", "false"])
+    args = parser.parse_args(["--slurm-disable-memory-fudge"])
     settings = plugin.get_settings(args)
 
-    assert settings.array_memory_fudge is False
+    assert settings.array_memory_fudge is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,8 +68,8 @@ def test_jobname_prefix_validation():
         executor.__post_init__(test_mode=True)
 
 
-def test_disable_memory_fudge_false_resolves_from_cli():
-    """The executor setting must not retain the truthy string ``"false"``."""
+def test_disable_memory_fudge_flag_resolves_from_cli():
+    """CLI flag is a no-argument switch that sets disable_memory_fudge=True."""
     plugin = _SlurmSettingsPlugin()
     parser = ArgumentParser()
     plugin.register_cli_args(parser, "executor")
@@ -77,7 +77,7 @@ def test_disable_memory_fudge_false_resolves_from_cli():
     args = parser.parse_args(["--slurm-disable-memory-fudge"])
     settings = plugin.get_settings(args)
 
-    assert settings.array_memory_fudge is True
+    assert settings.disable_memory_fudge is True
 
 
 def test_requeue_options_are_mutually_exclusive():


### PR DESCRIPTION
Per default array jobs get a higher memory setting, a "memory fudge". This new PR is based on #477 . It allows disabling the memory fudge setting.

Here, the `--slurm-array-memory-fudge` flag is renamed in favour of `--slurm-disable-memory-fudge`. Reasoning: The development will eventually entail pooling of shared memory programs onto one or multiple nodes. For this feature as well of array jobs this extra memory might be required. Disabling it should not carry the `array` string, as this might introduce a breaking change in a future release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable memory adjustment for Slurm array jobs.
  * Array-job memory requests now increase by default, with a minimal-memory fallback when needed.
  * Added CLI and profile options to disable automatic memory adjustment.

* **Documentation**
  * Documented default memory behavior, fallback handling, and configuration options for array jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->